### PR TITLE
feat: auto-discover .slnx solution files alongside .sln

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ dotnet tool update --global --add-source ./nupkg roslyn-query
 
 ## Usage
 
-```
-roslyn-query <command> <symbol> [solution.sln] [flags]
+```text
+roslyn-query <command> <symbol> [solution.sln|.slnx] [flags]
 ```
 
-If the solution path is omitted, the tool walks up from the current directory to find a `.sln` file.
+If the solution path is omitted, the tool walks up from the current directory to find a `.sln` or `.slnx` file.
 
 ### Symbol format
 
@@ -225,7 +225,7 @@ roslyn-query daemon stop
 roslyn-query daemon stop MySolution.sln
 ```
 
-If the solution path is omitted, the tool searches parent directories for a `.sln` file, same as normal commands.
+If the solution path is omitted, the tool searches parent directories for a `.sln` or `.slnx` file, same as normal commands.
 
 ## Performance notes
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Requires .NET 10 SDK.
 git clone https://github.com/karirafn/roslyn-query.git
 cd roslyn-query
 dotnet pack
-dotnet tool install --global --add-source ./nupkg roslyn-query
+dotnet tool install --global --add-source ./src/bin/Release roslyn-query
 ```
 
 To update after pulling new changes:
 
 ```bash
 dotnet pack
-dotnet tool update --global --add-source ./nupkg roslyn-query
+dotnet tool update --global --add-source ./src/bin/Release roslyn-query
 ```
 
 ## Usage

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -52,7 +52,7 @@ public static class CommandDispatcher
 
     internal static async Task PrintUsageAsync(TextWriter stderr)
     {
-        await stderr.WriteLineAsync("Usage: roslyn-query <command> <symbol> [solution.sln] [flags]");
+        await stderr.WriteLineAsync("Usage: roslyn-query <command> <symbol> [solution.sln|.slnx] [flags]");
         await stderr.WriteLineAsync();
         await stderr.WriteLineAsync("Commands:");
         await stderr.WriteLineAsync(
@@ -76,7 +76,7 @@ public static class CommandDispatcher
         await stderr.WriteLineAsync(
             "  list-types <Namespace>     All types in a namespace (prefix match)");
         await stderr.WriteLineAsync(
-            "  daemon stop [solution.sln] Stop the background daemon for a solution");
+            "  daemon stop [solution.sln|.slnx] Stop the background daemon for a solution");
         await stderr.WriteLineAsync();
         await stderr.WriteLineAsync("Flags:");
         await stderr.WriteLineAsync(
@@ -90,10 +90,10 @@ public static class CommandDispatcher
         await stderr.WriteLineAsync();
         await stderr.WriteLineAsync("Internal:");
         await stderr.WriteLineAsync(
-            "  --daemon <solution.sln>    Run as daemon server for the given solution");
+            "  --daemon <solution.sln|.slnx> Run as daemon server for the given solution");
         await stderr.WriteLineAsync();
         await stderr.WriteLineAsync(
-            "If solution path is omitted, searches parent directories for a .sln file.");
+            "If solution path is omitted, searches parent directories for a .sln or .slnx file.");
         await stderr.WriteLineAsync("Symbol format: TypeName  or  TypeName.MemberName");
         await stderr.WriteLineAsync();
         await stderr.WriteLineAsync(

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -53,7 +53,7 @@ static int RunDaemonStop(string[] args)
 {
     string? solutionPath = args.Length >= 3
         ? Path.GetFullPath(args[2])
-        : DiscoverSolution();
+        : SolutionDiscovery.Discover(Directory.GetCurrentDirectory(), Console.Error);
 
     if (solutionPath is null)
     {
@@ -145,29 +145,7 @@ static string? ResolveSolutionPath(string[] args)
         return Path.GetFullPath(explicitPath);
     }
 
-    return DiscoverSolution();
-}
-
-static string? DiscoverSolution()
-{
-    string? dir = Directory.GetCurrentDirectory();
-    while (!string.IsNullOrEmpty(dir))
-    {
-        string[] slns = Directory.GetFiles(dir, "*.sln");
-        if (slns.Length == 1)
-        {
-            return slns[0];
-        }
-        if (slns.Length > 1)
-        {
-            Console.Error.WriteLine(
-                $"Multiple .sln files in {dir} — specify one explicitly.");
-            return null;
-        }
-        dir = Path.GetDirectoryName(dir);
-    }
-    Console.Error.WriteLine("No .sln file found in current or parent directories.");
-    return null;
+    return SolutionDiscovery.Discover(Directory.GetCurrentDirectory(), Console.Error);
 }
 
 static async Task<MSBuildWorkspace> OpenWorkspace(string solutionPath, bool quiet)

--- a/src/SolutionDiscovery.cs
+++ b/src/SolutionDiscovery.cs
@@ -1,0 +1,32 @@
+namespace RoslynQuery;
+
+public static class SolutionDiscovery
+{
+    public static string? Discover(string startDir, TextWriter stderr)
+    {
+        ArgumentNullException.ThrowIfNull(startDir);
+        ArgumentNullException.ThrowIfNull(stderr);
+        string? dir = startDir;
+        while (!string.IsNullOrEmpty(dir))
+        {
+            string[] slns =
+            [
+                .. Directory.GetFiles(dir, "*.sln"),
+                .. Directory.GetFiles(dir, "*.slnx"),
+            ];
+            if (slns.Length == 1)
+            {
+                return slns[0];
+            }
+            if (slns.Length > 1)
+            {
+                stderr.WriteLine(
+                    $"Multiple solution files in {dir} — specify one explicitly.");
+                return null;
+            }
+            dir = Path.GetDirectoryName(dir);
+        }
+        stderr.WriteLine("No .sln or .slnx file found in current or parent directories.");
+        return null;
+    }
+}

--- a/tests/SolutionDiscoveryTests/Discover.cs
+++ b/tests/SolutionDiscoveryTests/Discover.cs
@@ -1,0 +1,129 @@
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.SolutionDiscoveryTests;
+
+public sealed class Discover
+{
+    [Fact]
+    public void WhenSlnxInCurrentDir_ReturnsSlnxPath()
+    {
+        // Arrange
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        string slnxPath = Path.Combine(dir, "my.slnx");
+        File.WriteAllText(slnxPath, "");
+        StringWriter stderr = new();
+
+        try
+        {
+            // Act
+            string? result = SolutionDiscovery.Discover(dir, stderr);
+
+            // Assert
+            result.ShouldBe(slnxPath);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenSlnInCurrentDir_ReturnsSlnPath()
+    {
+        // Arrange
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        string slnPath = Path.Combine(dir, "my.sln");
+        File.WriteAllText(slnPath, "");
+        StringWriter stderr = new();
+
+        try
+        {
+            // Act
+            string? result = SolutionDiscovery.Discover(dir, stderr);
+
+            // Assert
+            result.ShouldBe(slnPath);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenSlnxInParentDir_ReturnsSlnxPath()
+    {
+        // Arrange
+        string parent = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string child = Path.Combine(parent, "sub");
+        Directory.CreateDirectory(child);
+        string slnxPath = Path.Combine(parent, "my.slnx");
+        File.WriteAllText(slnxPath, "");
+        StringWriter stderr = new();
+
+        try
+        {
+            // Act
+            string? result = SolutionDiscovery.Discover(child, stderr);
+
+            // Assert
+            result.ShouldBe(slnxPath);
+        }
+        finally
+        {
+            Directory.Delete(parent, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenMultipleSlnFiles_ReturnsNullAndWritesError()
+    {
+        // Arrange
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "a.sln"), "");
+        File.WriteAllText(Path.Combine(dir, "b.sln"), "");
+        StringWriter stderr = new();
+
+        try
+        {
+            // Act
+            string? result = SolutionDiscovery.Discover(dir, stderr);
+
+            // Assert
+            result.ShouldBeNull();
+            stderr.ToString().ShouldContain("specify one explicitly");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenNoSolutionFound_ReturnsNullAndWritesError()
+    {
+        // Arrange
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        StringWriter stderr = new();
+
+        try
+        {
+            // Act
+            string? result = SolutionDiscovery.Discover(dir, stderr);
+
+            // Assert
+            result.ShouldBeNull();
+            stderr.ToString().ShouldContain("No .sln");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extends auto-discovery to find `.slnx` files when walking parent directories (previously only `.sln` was searched)
- Extracts `DiscoverSolution` from `Program.cs` into a new public `SolutionDiscovery` class to make it testable
- Explicit `.slnx` path arguments were already accepted — this closes the gap for auto-discovery

## Test plan

- [ ] `WhenSlnxInCurrentDir_ReturnsSlnxPath` — auto-discovers `.slnx` in cwd
- [ ] `WhenSlnxInParentDir_ReturnsSlnxPath` — walks up to find `.slnx`
- [ ] `WhenSlnInCurrentDir_ReturnsSlnPath` — existing `.sln` behaviour unchanged
- [ ] `WhenMultipleSlnFiles_ReturnsNullAndWritesError` — ambiguous case still errors
- [ ] `WhenNoSolutionFound_ReturnsNullAndWritesError` — no-solution case still errors