### PR TITLE
Add --count flag to output result count instead of full list

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ interface	MyApp.Orders.IOrderRepository	src/Orders/IOrderRepository.cs:3
 | `--absolute` | Emit absolute file paths (default: relative to solution directory) |
 | `--limit N` | Cap output to N lines per query; prints `... (N more, omit --limit to see all)` to stderr when truncated |
 | `--compact` | Emit short symbol names (`TypeName.MemberName`) instead of fully-qualified display strings — applies to `find-callers` and `find-overrides` |
+| `--count` | Print only the integer result count to stdout; suppresses file:line output. Not supported on `find-base` or `list-members`. Mutually exclusive with `--limit` |
 
 ## Batch queries
 

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Globalization;
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
@@ -23,6 +24,7 @@ public static class CommandDispatcher
         bool inherited = args.Any(a => a is "--inherited");
         bool absolute = args.Any(a => a is "--absolute");
         bool compact = args.Any(a => a is "--compact");
+        bool count = args.Any(a => a is "--count");
 
         int limit = 0;
         int limitIdx = Array.IndexOf(args, "--limit");
@@ -47,7 +49,7 @@ public static class CommandDispatcher
         string[] filteredArgs = args
             .Where((a, i) => a is not (
                 "--quiet" or "-q" or "--context" or "--all"
-                or "--inherited" or "--absolute" or "--compact")
+                or "--inherited" or "--absolute" or "--compact" or "--count")
                 && !limitIndicesToSkip.Contains(i))
             .ToArray();
 
@@ -66,11 +68,36 @@ public static class CommandDispatcher
             basePath = null;
         }
 
+        if (count && limit > 0)
+        {
+            await context.Stderr.WriteLineAsync(
+                "--count and --limit are mutually exclusive");
+            return 1;
+        }
+
+        if (count && command is "find-base" or "list-members")
+        {
+            await context.Stderr.WriteLineAsync(
+                $"--count is not supported on {command}");
+            return 1;
+        }
+
         LimitedWriter? limitedWriter = null;
         TextWriter originalStdout = context.Stdout;
         CommandContext effectiveContext = context;
 
-        if (limit > 0)
+        CountingWriter? countingWriter = null;
+
+        if (count)
+        {
+            countingWriter = new CountingWriter();
+            effectiveContext = new CommandContext(
+                countingWriter,
+                TextWriter.Null,
+                context.Solution,
+                context.SolutionDirectory);
+        }
+        else if (limit > 0)
         {
             limitedWriter = new LimitedWriter(originalStdout, limit);
             effectiveContext = new CommandContext(
@@ -97,6 +124,12 @@ public static class CommandDispatcher
             "list-types" => await ListTypes(rest, showContext, basePath, effectiveContext),
             _ => await FailAsync($"Unknown command: {command}", effectiveContext.Stderr),
         };
+
+        if (countingWriter is not null)
+        {
+            await originalStdout.WriteLineAsync(
+                countingWriter.Count.ToString(CultureInfo.InvariantCulture));
+        }
 
         if (limitedWriter is { Suppressed: > 0 })
         {

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -185,6 +185,8 @@ public static class CommandDispatcher
             "  --limit N                  Cap output to N lines (remainder count on stderr)");
         await stderr.WriteLineAsync(
             "  --compact                  Short symbol names in find-callers/find-overrides");
+        await stderr.WriteLineAsync(
+            "  --count                    Print only the result count (not supported on find-base or list-members)");
         await stderr.WriteLineAsync();
         await stderr.WriteLineAsync("Internal:");
         await stderr.WriteLineAsync(

--- a/src/CountingWriter.cs
+++ b/src/CountingWriter.cs
@@ -15,4 +15,14 @@ public sealed class CountingWriter : TextWriter
             Count++;
         }
     }
+
+    public override Task WriteLineAsync(string? value)
+    {
+        if (value is null || !value.StartsWith(HeaderPrefix, StringComparison.Ordinal))
+        {
+            Count++;
+        }
+
+        return Task.CompletedTask;
+    }
 }

--- a/src/CountingWriter.cs
+++ b/src/CountingWriter.cs
@@ -1,0 +1,18 @@
+namespace RoslynQuery;
+
+public sealed class CountingWriter : TextWriter
+{
+    private const string HeaderPrefix = "# ";
+
+    public int Count { get; private set; }
+
+    public override System.Text.Encoding Encoding => System.Text.Encoding.UTF8;
+
+    public override void WriteLine(string? value)
+    {
+        if (value is null || !value.StartsWith(HeaderPrefix, StringComparison.Ordinal))
+        {
+            Count++;
+        }
+    }
+}

--- a/tests/CommandDispatcherTests/FlagParsing.cs
+++ b/tests/CommandDispatcherTests/FlagParsing.cs
@@ -59,4 +59,75 @@ public sealed class FlagParsing
         exitCode.ShouldBe(1);
         stderr.ToString().ShouldContain("find-refs requires a symbol name");
     }
+
+    [Fact]
+    public async Task WhenCountFlagProvided_StripsFromArgs()
+    {
+        // Arrange
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution: null!);
+
+        // Act
+        await CommandDispatcher.ExecuteAsync(
+            ["find-refs", "--count"],
+            context);
+
+        // Assert — flag is stripped so "find-refs" is the command, not "--count"
+        stderr.ToString().ShouldNotContain("Unknown command: --count");
+    }
+
+    [Fact]
+    public async Task WhenCountAndLimitProvided_ReturnsMutuallyExclusiveError()
+    {
+        // Arrange
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution: null!);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["find-refs", "Foo", "--count", "--limit", "10"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(1);
+        stderr.ToString().ShouldContain("--count and --limit are mutually exclusive");
+    }
+
+    [Fact]
+    public async Task WhenCountOnFindBase_ReturnsUnsupportedError()
+    {
+        // Arrange
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution: null!);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["find-base", "Foo", "--count"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(1);
+        stderr.ToString().ShouldContain("--count is not supported on find-base");
+    }
+
+    [Fact]
+    public async Task WhenCountOnListMembers_ReturnsUnsupportedError()
+    {
+        // Arrange
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution: null!);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["list-members", "Foo", "--count"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(1);
+        stderr.ToString().ShouldContain("--count is not supported on list-members");
+    }
 }

--- a/tests/CountingWriterTests/WriteLine.cs
+++ b/tests/CountingWriterTests/WriteLine.cs
@@ -1,0 +1,76 @@
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.CountingWriterTests;
+
+public sealed class WriteLine
+{
+    [Fact]
+    public void WhenLinesWritten_CountsAll()
+    {
+        // Arrange
+        CountingWriter writer = new();
+
+        // Act
+        writer.WriteLine("line 1");
+        writer.WriteLine("line 2");
+        writer.WriteLine("line 3");
+
+        // Assert
+        writer.Count.ShouldBe(3);
+    }
+
+    [Fact]
+    public void WhenHeaderLineWritten_DoesNotCount()
+    {
+        // Arrange
+        CountingWriter writer = new();
+
+        // Act
+        writer.WriteLine("# Foo.Bar");
+
+        // Assert
+        writer.Count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void WhenMixedHeaderAndResultLines_CountsOnlyResults()
+    {
+        // Arrange
+        CountingWriter writer = new();
+
+        // Act
+        writer.WriteLine("# Foo.Bar");
+        writer.WriteLine("src/Foo.cs:10");
+        writer.WriteLine("src/Bar.cs:20");
+
+        // Assert
+        writer.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void WhenNullValueWritten_CountsIt()
+    {
+        // Arrange
+        CountingWriter writer = new();
+
+        // Act
+        writer.WriteLine((string?)null);
+
+        // Assert
+        writer.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void WhenNoLinesWritten_CountIsZero()
+    {
+        // Arrange
+        CountingWriter writer = new();
+
+        // Act — nothing
+
+        // Assert
+        writer.Count.ShouldBe(0);
+    }
+}

--- a/tests/CountingWriterTests/WriteLine.cs
+++ b/tests/CountingWriterTests/WriteLine.cs
@@ -73,4 +73,31 @@ public sealed class WriteLine
         // Assert
         writer.Count.ShouldBe(0);
     }
+
+    [Fact]
+    public async Task WhenLineWrittenAsync_CountsIt()
+    {
+        // Arrange
+        CountingWriter writer = new();
+
+        // Act
+        await writer.WriteLineAsync("line 1");
+        await writer.WriteLineAsync("line 2");
+
+        // Assert
+        writer.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task WhenHeaderLineWrittenAsync_DoesNotCount()
+    {
+        // Arrange
+        CountingWriter writer = new();
+
+        // Act
+        await writer.WriteLineAsync("# Foo.Bar");
+
+        // Assert
+        writer.Count.ShouldBe(0);
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `--count` flag that suppresses file:line output and prints only the integer result count to stdout
- Validates mutual exclusivity with `--limit`; blocks `--count` on `find-base` and `list-members`
- `--count --all` sums across all symbol groups by skipping header lines

## Test plan

- [x] `CountingWriter` unit tests — sync and async paths, header skipping, null handling, zero baseline
- [x] `CommandDispatcher` flag parsing tests — stripping, mutual exclusivity, unsupported command errors
- [x] All 117 tests passing

Closes #9