### PR TITLE
fix: increase idle timeout test delay for CI reliability

### DIFF
--- a/tests/DaemonIntegrationTests/IdleTimeout.cs
+++ b/tests/DaemonIntegrationTests/IdleTimeout.cs
@@ -11,7 +11,7 @@ public sealed class IdleTimeout
         using CancellationTokenSource cts = new(TimeSpan.FromMilliseconds(200));
 
         // Act
-        await Task.Delay(500);
+        await Task.Delay(2000);
 
         // Assert
         cts.Token.IsCancellationRequested.ShouldBeTrue();
@@ -27,7 +27,7 @@ public sealed class IdleTimeout
             CancellationTokenSource.CreateLinkedTokenSource(externalCts.Token, idleCts.Token);
 
         // Act
-        await Task.Delay(500);
+        await Task.Delay(2000);
 
         // Assert
         linkedCts.Token.IsCancellationRequested.ShouldBeTrue();


### PR DESCRIPTION
## Summary

Increases `Task.Delay` from 500ms to 2000ms in both `IdleTimeout` tests, giving a 10x margin over the 200ms cancellation timeout. This eliminates the race condition on slow CI runners where 500ms was insufficient headroom.

Fixes pre-existing CI failure.

Related: #14