### PR TITLE
Add describe command for compact type overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,29 @@ class	MyApp.Orders.OrderAggregate	src/Orders/OrderAggregate.cs:5
 interface	MyApp.Orders.IOrderRepository	src/Orders/IOrderRepository.cs:3
 ```
 
+### describe
+
+Summary card for a type: kind, fully-qualified name, source location, base type, implemented interfaces, and member counts.
+
+```bash
+roslyn-query describe CommandDispatcher
+```
+
+Output:
+
+```text
+class RoslynQuery.CommandDispatcher  src/CommandDispatcher.cs:9
+base:       SomeBase
+interfaces: IFoo, IBar
+members:    2 ctors, 5 props, 3 methods
+```
+
+The `base` line is omitted when the type has no base type (or only inherits from `System.Object`).
+The `interfaces` line is omitted when the type implements no interfaces.
+The `members` line is omitted when the type has no members.
+
+Supports the `--absolute` flag to emit absolute file paths in the header line.
+
 ## Flags
 
 | Flag | Description |

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Globalization;
 
 using Microsoft.CodeAnalysis;
@@ -989,6 +990,53 @@ public static class CommandDispatcher
             string interfaces = string.Join(", ", target.Interfaces.Select(i => i.Name));
             await ctx.Stdout.WriteLineAsync(
                 $"interfaces: {interfaces}");
+        }
+
+        ImmutableArray<ISymbol> members = target.GetMembers();
+        int ctors = 0;
+        int props = 0;
+        int methods = 0;
+        int fields = 0;
+        int events = 0;
+
+        foreach (ISymbol member in members)
+        {
+            if (member.IsImplicitlyDeclared)
+            {
+                continue;
+            }
+
+            switch (member)
+            {
+                case IMethodSymbol { MethodKind: MethodKind.Constructor }:
+                    ctors++;
+                    break;
+                case IPropertySymbol:
+                    props++;
+                    break;
+                case IMethodSymbol { MethodKind: MethodKind.Ordinary }:
+                    methods++;
+                    break;
+                case IFieldSymbol:
+                    fields++;
+                    break;
+                case IEventSymbol:
+                    events++;
+                    break;
+            }
+        }
+
+        List<string> parts = [];
+        if (ctors > 0) { parts.Add($"{ctors} ctors"); }
+        if (props > 0) { parts.Add($"{props} props"); }
+        if (methods > 0) { parts.Add($"{methods} methods"); }
+        if (fields > 0) { parts.Add($"{fields} fields"); }
+        if (events > 0) { parts.Add($"{events} events"); }
+
+        if (parts.Count > 0)
+        {
+            await ctx.Stdout.WriteLineAsync(
+                $"members:    {string.Join(", ", parts)}");
         }
 
         return 0;

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -964,8 +964,19 @@ public static class CommandDispatcher
         }
 
         INamedTypeSymbol target = matches[0];
-        _ = target;
-        _ = basePath;
+
+        Location? targetLoc = target.Locations.FirstOrDefault(l => l.IsInSource);
+        string location = targetLoc is not null
+            ? FormatLocation(
+                targetLoc.GetLineSpan(),
+                context: false,
+                targetLoc.SourceTree,
+                basePath)
+            : "(external)";
+        string kind = FormatTypeKind(target.TypeKind);
+        await ctx.Stdout.WriteLineAsync(
+            $"{kind} {target.ToDisplayString()}  {location}");
+
         return 0;
     }
 

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -984,6 +984,13 @@ public static class CommandDispatcher
                 $"base:       {target.BaseType.Name}");
         }
 
+        if (target.Interfaces.Length > 0)
+        {
+            string interfaces = string.Join(", ", target.Interfaces.Select(i => i.Name));
+            await ctx.Stdout.WriteLineAsync(
+                $"interfaces: {interfaces}");
+        }
+
         return 0;
     }
 

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -977,6 +977,13 @@ public static class CommandDispatcher
         await ctx.Stdout.WriteLineAsync(
             $"{kind} {target.ToDisplayString()}  {location}");
 
+        if (target.BaseType is not null
+            && target.BaseType.SpecialType != SpecialType.System_Object)
+        {
+            await ctx.Stdout.WriteLineAsync(
+                $"base:       {target.BaseType.Name}");
+        }
+
         return 0;
     }
 

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -916,6 +916,55 @@ public static class CommandDispatcher
             return await FailAsync("describe requires a type name", ctx.Stderr);
         }
 
+        string typeName = args[0];
+        Solution solution = ctx.Solution;
+
+        List<INamedTypeSymbol> matches = [];
+        HashSet<string> seen = new();
+
+        foreach (Project project in solution.Projects)
+        {
+            Compilation? compilation = await project.GetCompilationAsync();
+            if (compilation is null)
+            {
+                continue;
+            }
+
+            IEnumerable<INamedTypeSymbol> candidates = compilation
+                .GetSymbolsWithName(typeName, SymbolFilter.Type)
+                .OfType<INamedTypeSymbol>()
+                .Where(t => t.Locations.Any(l => l.IsInSource));
+
+            foreach (INamedTypeSymbol candidate in candidates)
+            {
+                string key = candidate.ToDisplayString();
+                if (seen.Add(key))
+                {
+                    matches.Add(candidate);
+                }
+            }
+        }
+
+        if (matches.Count == 0)
+        {
+            return await FailAsync($"Type not found: {typeName}", ctx.Stderr);
+        }
+
+        if (matches.Count > 1)
+        {
+            await ctx.Stderr.WriteLineAsync(
+                $"Ambiguous '{typeName}' — {matches.Count} matches:");
+            foreach (INamedTypeSymbol t in matches)
+            {
+                await ctx.Stderr.WriteLineAsync($"  {t.ToDisplayString()}");
+            }
+            await ctx.Stderr.WriteLineAsync(
+                "Use a fully-qualified name to disambiguate.");
+            return 1;
+        }
+
+        INamedTypeSymbol target = matches[0];
+        _ = target;
         _ = basePath;
         return 0;
     }

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -210,6 +210,17 @@ public static class CommandDispatcher
         string? basePath = null)
         => LocationFormatter.Format(span, context, tree, basePath);
 
+    private static string FormatTypeKind(TypeKind kind) => kind switch
+    {
+        TypeKind.Class => "class",
+        TypeKind.Interface => "interface",
+        TypeKind.Struct => "struct",
+        TypeKind.Enum => "enum",
+        TypeKind.Delegate => "delegate",
+        TypeKind.Module => "module",
+        _ => kind.ToString(),
+    };
+
     public static string FormatSymbolName(ISymbol symbol, bool compact)
     {
         ArgumentNullException.ThrowIfNull(symbol);
@@ -958,16 +969,7 @@ public static class CommandDispatcher
 
                 FileLinePositionSpan span = loc.GetLineSpan();
                 string location = FormatLocation(span, context, loc.SourceTree, basePath);
-                string typeKind = type.TypeKind switch
-                {
-                    TypeKind.Class => "class",
-                    TypeKind.Interface => "interface",
-                    TypeKind.Struct => "struct",
-                    TypeKind.Enum => "enum",
-                    TypeKind.Delegate => "delegate",
-                    TypeKind.Module => "module",
-                    _ => type.TypeKind.ToString(),
-                };
+                string typeKind = FormatTypeKind(type.TypeKind);
                 await ctx.Stdout.WriteLineAsync(
                     $"{typeKind}\t{type.ToDisplayString()}\t{location}");
                 count++;

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -75,7 +75,7 @@ public static class CommandDispatcher
             return 1;
         }
 
-        if (count && command is "find-base" or "list-members")
+        if (count && command is "find-base" or "list-members" or "describe")
         {
             await context.Stderr.WriteLineAsync(
                 $"--count is not supported on {command}");
@@ -122,6 +122,7 @@ public static class CommandDispatcher
             "find-unused" => await FindUnused(showContext, basePath, effectiveContext),
             "list-members" => await ListMembers(rest, inherited, all, effectiveContext),
             "list-types" => await ListTypes(rest, showContext, basePath, effectiveContext),
+            "describe" => await Describe(rest, basePath, effectiveContext),
             _ => await FailAsync($"Unknown command: {command}", effectiveContext.Stderr),
         };
 
@@ -892,6 +893,19 @@ public static class CommandDispatcher
             }
         }
 
+        return 0;
+    }
+
+    // -- describe -----------------------------------------------------------------
+
+    private static async Task<int> Describe(string[] args, string? basePath, CommandContext ctx)
+    {
+        if (args.Length == 0)
+        {
+            return await FailAsync("describe requires a type name", ctx.Stderr);
+        }
+
+        _ = basePath;
         return 0;
     }
 

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -168,6 +168,8 @@ public static class CommandDispatcher
         await stderr.WriteLineAsync(
             "  list-types <Namespace>     All types in a namespace (prefix match)");
         await stderr.WriteLineAsync(
+            "  describe <Type>            Summary card: kind, location, base, interfaces, member counts");
+        await stderr.WriteLineAsync(
             "  batch                      Read commands from stdin, one per line (uses daemon)");
         await stderr.WriteLineAsync(
             "  daemon stop [solution.sln|.slnx] Stop the background daemon for a solution");

--- a/tests/CommandDispatcherTests/DescribeCommand.cs
+++ b/tests/CommandDispatcherTests/DescribeCommand.cs
@@ -61,6 +61,29 @@ namespace Beta
         error.ShouldContain("Beta.Widget");
     }
 
+    [Fact]
+    public async Task WhenClassType_OutputsHeaderLine()
+    {
+        // Arrange
+        string source = @"
+namespace App;
+class MyService { }";
+        Solution solution = CreateSolution(source);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["describe", "MyService"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        string[] lines = stdout.ToString().TrimEnd().Split(Environment.NewLine);
+        lines[0].ShouldBe("class App.MyService  Test.cs:3");
+    }
+
     private static Solution CreateSolution(string source)
     {
         AdhocWorkspace workspace = new();

--- a/tests/CommandDispatcherTests/DescribeCommand.cs
+++ b/tests/CommandDispatcherTests/DescribeCommand.cs
@@ -131,6 +131,78 @@ class Standalone { }";
         lines.ShouldAllBe(line => !line.StartsWith("base:"));
     }
 
+    [Fact]
+    public async Task WhenTypeWithInterfaces_OutputsInterfacesLine()
+    {
+        // Arrange
+        string source = @"
+namespace App;
+interface IFoo { }
+interface IBar { }
+class Widget : IFoo, IBar { }";
+        Solution solution = CreateSolution(source);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["describe", "Widget"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        string output = stdout.ToString();
+        output.ShouldContain("interfaces: IFoo, IBar");
+    }
+
+    [Fact]
+    public async Task WhenTypeWithoutInterfaces_OmitsInterfacesLine()
+    {
+        // Arrange
+        string source = @"
+namespace App;
+class Plain { }";
+        Solution solution = CreateSolution(source);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["describe", "Plain"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        string[] lines = stdout.ToString().TrimEnd().Split(Environment.NewLine);
+        lines.ShouldAllBe(line => !line.StartsWith("interfaces:"));
+    }
+
+    [Fact]
+    public async Task WhenInterface_ShowsExtendedInterfaces()
+    {
+        // Arrange
+        string source = @"
+namespace App;
+interface IBase { }
+interface IChild : IBase { }";
+        Solution solution = CreateSolution(source);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["describe", "IChild"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        string output = stdout.ToString();
+        output.ShouldContain("interfaces: IBase");
+    }
+
     private static Solution CreateSolution(string source)
     {
         AdhocWorkspace workspace = new();

--- a/tests/CommandDispatcherTests/DescribeCommand.cs
+++ b/tests/CommandDispatcherTests/DescribeCommand.cs
@@ -203,6 +203,84 @@ interface IChild : IBase { }";
         output.ShouldContain("interfaces: IBase");
     }
 
+    [Fact]
+    public async Task WhenTypeWithMembers_OutputsMembersLine()
+    {
+        // Arrange
+        string source = @"
+namespace App;
+class Service
+{
+    public Service() { }
+    public Service(int x) { }
+    public string Name { get; set; }
+    public int Count { get; }
+    public void DoWork() { }
+    public int Calculate(int x) { return x; }
+    public void Reset() { }
+}";
+        Solution solution = CreateSolution(source);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["describe", "Service"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        string output = stdout.ToString();
+        output.ShouldContain("members:    2 ctors, 2 props, 3 methods");
+    }
+
+    [Fact]
+    public async Task WhenTypeWithNoMembers_OmitsMembersLine()
+    {
+        // Arrange
+        string source = @"
+namespace App;
+interface IEmpty { }";
+        Solution solution = CreateSolution(source);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["describe", "IEmpty"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        string[] lines = stdout.ToString().TrimEnd().Split(Environment.NewLine);
+        lines.ShouldAllBe(line => !line.StartsWith("members:"));
+    }
+
+    [Fact]
+    public async Task WhenEnum_OutputsFieldCount()
+    {
+        // Arrange
+        string source = @"
+namespace App;
+enum Color { Red, Green, Blue }";
+        Solution solution = CreateSolution(source);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["describe", "Color"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        string output = stdout.ToString();
+        output.ShouldContain("members:    3 fields");
+    }
+
     private static Solution CreateSolution(string source)
     {
         AdhocWorkspace workspace = new();

--- a/tests/CommandDispatcherTests/DescribeCommand.cs
+++ b/tests/CommandDispatcherTests/DescribeCommand.cs
@@ -84,6 +84,53 @@ class MyService { }";
         lines[0].ShouldBe("class App.MyService  Test.cs:3");
     }
 
+    [Fact]
+    public async Task WhenClassWithBase_OutputsBaseLine()
+    {
+        // Arrange
+        string source = @"
+namespace App;
+class Animal { }
+class Dog : Animal { }";
+        Solution solution = CreateSolution(source);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["describe", "Dog"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        string output = stdout.ToString();
+        output.ShouldContain("base:       Animal");
+    }
+
+    [Fact]
+    public async Task WhenClassWithoutBase_OmitsBaseLine()
+    {
+        // Arrange
+        string source = @"
+namespace App;
+class Standalone { }";
+        Solution solution = CreateSolution(source);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["describe", "Standalone"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        string[] lines = stdout.ToString().TrimEnd().Split(Environment.NewLine);
+        lines.ShouldAllBe(line => !line.StartsWith("base:"));
+    }
+
     private static Solution CreateSolution(string source)
     {
         AdhocWorkspace workspace = new();

--- a/tests/CommandDispatcherTests/DescribeCommand.cs
+++ b/tests/CommandDispatcherTests/DescribeCommand.cs
@@ -1,0 +1,84 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.CommandDispatcherTests;
+
+public sealed class DescribeCommand
+{
+    [Fact]
+    public async Task WhenTypeNotFound_ReturnsError()
+    {
+        // Arrange
+        string source = @"
+namespace TestApp;
+class Foo { }";
+        Solution solution = CreateSolution(source);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["describe", "NonExistentXyz"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(1);
+        stderr.ToString().ShouldContain("Type not found");
+    }
+
+    [Fact]
+    public async Task WhenAmbiguousType_ReturnsDisambiguationHint()
+    {
+        // Arrange
+        string source = @"
+namespace Alpha
+{
+    class Widget { }
+}
+namespace Beta
+{
+    class Widget { }
+}";
+        Solution solution = CreateSolution(source);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["describe", "Widget"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(1);
+        string error = stderr.ToString();
+        error.ShouldContain("Alpha.Widget");
+        error.ShouldContain("Beta.Widget");
+    }
+
+    private static Solution CreateSolution(string source)
+    {
+        AdhocWorkspace workspace = new();
+        ProjectInfo projectInfo = ProjectInfo.Create(
+            ProjectId.CreateNewId(),
+            VersionStamp.Default,
+            "TestProject",
+            "TestProject",
+            LanguageNames.CSharp,
+            metadataReferences:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            ]);
+        Project project = workspace.AddProject(projectInfo);
+        Document document = workspace.AddDocument(
+            project.Id,
+            "Test.cs",
+            SourceText.From(source));
+        return document.Project.Solution;
+    }
+}

--- a/tests/CommandDispatcherTests/DescribeCommand.cs
+++ b/tests/CommandDispatcherTests/DescribeCommand.cs
@@ -281,7 +281,40 @@ enum Color { Red, Green, Blue }";
         output.ShouldContain("members:    3 fields");
     }
 
-    private static Solution CreateSolution(string source)
+    [Fact]
+    public async Task WhenAbsoluteFlag_OutputsAbsolutePath()
+    {
+        // Arrange
+        string absolutePath = Path.Combine(
+            Path.GetTempPath(), "myapp", "src", "Test.cs");
+        string solutionDir = Path.Combine(
+            Path.GetTempPath(), "myapp");
+        string source = @"
+namespace App;
+class MyService { }";
+        Solution solution = CreateSolution(source, absolutePath);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution, solutionDir);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["describe", "MyService", "--absolute"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        string[] lines = stdout.ToString().TrimEnd().Split(Environment.NewLine);
+        string headerLine = lines[0];
+        headerLine.ShouldContain(absolutePath);
+        string locationPart = headerLine.Split("  ")[1];
+        string pathPart = locationPart[..locationPart.LastIndexOf(':')];
+        Path.IsPathRooted(pathPart).ShouldBeTrue();
+    }
+
+    private static Solution CreateSolution(
+        string source,
+        string? documentPath = null)
     {
         AdhocWorkspace workspace = new();
         ProjectInfo projectInfo = ProjectInfo.Create(
@@ -297,7 +330,7 @@ enum Color { Red, Green, Blue }";
         Project project = workspace.AddProject(projectInfo);
         Document document = workspace.AddDocument(
             project.Id,
-            "Test.cs",
+            documentPath ?? "Test.cs",
             SourceText.From(source));
         return document.Project.Solution;
     }

--- a/tests/CommandDispatcherTests/ExecuteAsync.cs
+++ b/tests/CommandDispatcherTests/ExecuteAsync.cs
@@ -183,6 +183,22 @@ public sealed class ExecuteAsync
     }
 
     [Fact]
+    public async Task WhenDescribeWithoutType_ReturnsOne()
+    {
+        // Arrange
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution: null!);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(["describe"], context);
+
+        // Assert
+        exitCode.ShouldBe(1);
+        stderr.ToString().ShouldContain("describe requires a type name");
+    }
+
+    [Fact]
     public async Task WhenFlagsOnly_PrintsUsageAndReturnsOne()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Adds `describe <Type>` command outputting a compact summary card: kind, fully-qualified name, declaration location, base class, interfaces, and member counts by category
- Replaces 2–3 chained calls (`find-base` + `list-members` + file read) when orienting on an unknown type
- Composes existing helpers (`FindTypeByName` search loop, `LocationFormatter`, `FormatTypeKind`) — no new Roslyn API surface

## Changes
- `src/CommandDispatcher.cs` — new `Describe` method, extracted `FormatTypeKind` helper, `describe` added to command switch and `--count` unsupported list, usage text updated
- `tests/CommandDispatcherTests/DescribeCommand.cs` — new test class covering all output lines, edge cases, ambiguity, `--absolute`
- `tests/CommandDispatcherTests/ExecuteAsync.cs` — dispatch-level test for missing type name arg
- `README.md` — `describe` command documented with output format example

## Test plan
- [ ] `dotnet test` passes (130 tests)
- [ ] `describe OrderAggregate` on a real solution outputs header, optional base/interfaces/members lines
- [ ] `describe AmbiguousName` errors with disambiguation hint when multiple matches exist
- [ ] `describe NonExistent` errors with "Type not found"
- [ ] `describe MyType --absolute` outputs absolute path in header line

Closes #10