### PR TITLE
fix: add frame length guard and daemon protocol error recovery

### DIFF
--- a/src/DaemonServer.cs
+++ b/src/DaemonServer.cs
@@ -111,6 +111,15 @@ public static class DaemonServer
                 {
                     break;
                 }
+#pragma warning disable CA1031 // Catch general exception to keep the daemon alive
+                catch (Exception) when (!linkedCts.Token.IsCancellationRequested)
+#pragma warning restore CA1031
+                {
+                    // Protocol errors (e.g. InvalidDataException from frame guard,
+                    // IOException from broken pipe) should not crash the daemon.
+                    // The pipe is disposed by the await using, so just continue
+                    // to accept the next connection.
+                }
             }
         }
         finally

--- a/src/PipeProtocol.cs
+++ b/src/PipeProtocol.cs
@@ -8,6 +8,7 @@ namespace RoslynQuery;
 public static class PipeProtocol
 {
     private const string Prefix = "roslyn-query-";
+    internal const int MaxFrameBytes = 64 * 1024 * 1024;
 
     public static string DerivePipeName(string solutionPath)
     {
@@ -99,6 +100,12 @@ public static class PipeProtocol
         byte[] lenBytes = new byte[4];
         await stream.ReadExactlyAsync(lenBytes, cancellationToken);
         int length = BinaryPrimitives.ReadInt32BigEndian(lenBytes);
+        if (length < 0 || length > MaxFrameBytes)
+        {
+            throw new InvalidDataException(
+                $"Frame length {length} is outside the allowed range [0, {MaxFrameBytes}].");
+        }
+
         byte[] payload = new byte[length];
         await stream.ReadExactlyAsync(payload, cancellationToken);
         return payload;

--- a/tests/DaemonIntegrationTests/ProtocolErrorResilience.cs
+++ b/tests/DaemonIntegrationTests/ProtocolErrorResilience.cs
@@ -1,0 +1,110 @@
+using System.Buffers.Binary;
+using System.IO.Pipes;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.DaemonIntegrationTests;
+
+public sealed class ProtocolErrorResilience
+{
+    [Fact]
+    public async Task DaemonSurvivesMaliciousClient_ThenServesValidClient()
+    {
+        // Arrange
+        string fakeSolutionPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".sln");
+        string pipeName = PipeProtocol.DerivePipeName(fakeSolutionPath);
+        int connectionsHandled = 0;
+
+        using CancellationTokenSource cts = new(TimeSpan.FromSeconds(10));
+
+        // Simulate a daemon loop that reads requests and handles protocol errors
+        Task serverTask = Task.Run(
+            async () =>
+            {
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    try
+                    {
+                        using NamedPipeServerStream pipe = new(
+                            pipeName,
+                            PipeDirection.InOut,
+                            1,
+                            PipeTransmissionMode.Byte,
+                            PipeOptions.Asynchronous);
+
+                        await pipe.WaitForConnectionAsync(cts.Token);
+
+                        string[] args = await PipeProtocol.ReadRequestAsync(
+                            pipe,
+                            cts.Token);
+
+                        await PipeProtocol.WriteResponseAsync(
+                            pipe,
+                            string.Join(" ", args),
+                            "",
+                            0);
+
+                        connectionsHandled++;
+                        pipe.Disconnect();
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        break;
+                    }
+                    catch (InvalidDataException) when (!cts.Token.IsCancellationRequested)
+                    {
+                        // Same pattern as DaemonServer — survive protocol errors
+                    }
+                    catch (IOException) when (!cts.Token.IsCancellationRequested)
+                    {
+                        // Broken pipe — survive and continue
+                    }
+                }
+            },
+            cts.Token);
+
+        // Act — malicious client sends a negative frame length
+        using (NamedPipeClientStream badClient = new(
+            ".",
+            pipeName,
+            PipeDirection.InOut,
+            PipeOptions.Asynchronous))
+        {
+            await badClient.ConnectAsync(cts.Token);
+            byte[] badLenBytes = new byte[4];
+            BinaryPrimitives.WriteInt32BigEndian(badLenBytes, -1);
+            await badClient.WriteAsync(badLenBytes, cts.Token);
+            await badClient.FlushAsync(cts.Token);
+        }
+
+        // Brief wait for the server to process the error and loop back
+        await Task.Delay(100, cts.Token);
+
+        // Act — valid client connects after the malicious one
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        int? exitCode = await DaemonClient.TryExecuteAsync(
+            fakeSolutionPath,
+            ["find-callers", "--symbol", "Foo.Bar"],
+            stdout,
+            stderr);
+
+        await cts.CancelAsync();
+
+        try
+        {
+            await serverTask;
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected
+        }
+
+        // Assert
+        exitCode.ShouldBe(0);
+        stdout.ToString().ShouldBe("find-callers --symbol Foo.Bar");
+        connectionsHandled.ShouldBe(1);
+    }
+}

--- a/tests/PipeProtocolTests/ReadFrameGuard.cs
+++ b/tests/PipeProtocolTests/ReadFrameGuard.cs
@@ -1,0 +1,81 @@
+using System.Buffers.Binary;
+using System.IO.Pipes;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.PipeProtocolTests;
+
+public sealed class ReadFrameGuard
+{
+    [Fact]
+    public async Task WhenLengthIsMaxInt32_ThrowsInvalidDataException()
+    {
+        // Arrange
+        using AnonymousPipeServerStream server = new(PipeDirection.Out);
+        using AnonymousPipeClientStream client = new(PipeDirection.In, server.ClientSafePipeHandle);
+
+        byte[] lenBytes = new byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(lenBytes, 0x7FFFFFFF);
+        await server.WriteAsync(lenBytes);
+        server.Close();
+
+        // Act & Assert
+        await Should.ThrowAsync<InvalidDataException>(
+            async () => await PipeProtocol.ReadRequestAsync(client, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenLengthIsNegative_ThrowsInvalidDataException()
+    {
+        // Arrange
+        using AnonymousPipeServerStream server = new(PipeDirection.Out);
+        using AnonymousPipeClientStream client = new(PipeDirection.In, server.ClientSafePipeHandle);
+
+        byte[] lenBytes = new byte[4];
+        BinaryPrimitives.WriteInt32BigEndian(lenBytes, -1);
+        await server.WriteAsync(lenBytes);
+        server.Close();
+
+        // Act & Assert
+        await Should.ThrowAsync<InvalidDataException>(
+            async () => await PipeProtocol.ReadRequestAsync(client, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task WhenLengthIsExactlyMaxFrameBytes_AcceptsFrame()
+    {
+        // Arrange
+        int maxFrameBytes = 64 * 1024 * 1024;
+        string largeStdout = new(' ', maxFrameBytes);
+        using MemoryStream stream = new();
+        await PipeProtocol.WriteResponseAsync(stream, largeStdout, "", 0);
+        stream.Position = 0;
+
+        // Act
+        (string stdout, _, int exitCode) =
+            await PipeProtocol.ReadResponseAsync(stream, CancellationToken.None);
+
+        // Assert
+        stdout.Length.ShouldBe(maxFrameBytes);
+        exitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public async Task WhenLengthIsBelowMax_RoundTripsCorrectly()
+    {
+        // Arrange
+        string[] args = ["describe", "--symbol", "Foo.Bar"];
+        using AnonymousPipeServerStream server = new(PipeDirection.Out);
+        using AnonymousPipeClientStream client = new(PipeDirection.In, server.ClientSafePipeHandle);
+
+        // Act
+        await PipeProtocol.WriteRequestAsync(server, args);
+        server.Close();
+        string[] result = await PipeProtocol.ReadRequestAsync(client, CancellationToken.None);
+
+        // Assert
+        result.ShouldBe(args);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a 64 MB upper-bound guard in `PipeProtocol.ReadFrameAsync` before buffer allocation to prevent unbounded heap allocation from untrusted length prefixes
- Add protocol/IO exception handling in `DaemonServer` so a malformed or malicious frame disconnects the client without crashing the daemon process

## Test plan
- [ ] `WhenLengthIsMaxInt32_ThrowsInvalidDataException` — 0x7FFFFFFF triggers the guard
- [ ] `WhenLengthIsNegative_ThrowsInvalidDataException` — negative length triggers the guard
- [ ] `WhenLengthIsExactlyMaxFrameBytes_AcceptsFrame` — 64 MB frame accepted and round-trips
- [ ] `WhenLengthIsBelowMax_RoundTripsCorrectly` — normal frames unaffected
- [ ] `DaemonSurvivesMaliciousClient_ThenServesValidClient` — daemon continues after a bad client

Closes #18