### PR TITLE
fix: remove unused stdout/stderr redirects that cause daemon deadlock

### DIFF
--- a/src/DaemonProcess.cs
+++ b/src/DaemonProcess.cs
@@ -73,8 +73,6 @@ public static class DaemonProcess
             FileName = "roslyn-query",
             CreateNoWindow = true,
             UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
         };
 
         startInfo.ArgumentList.Add("--daemon");

--- a/tests/DaemonProcessTests/BuildStartInfo.cs
+++ b/tests/DaemonProcessTests/BuildStartInfo.cs
@@ -32,4 +32,30 @@ public sealed class BuildStartInfo
         // Assert
         result.ArgumentList[1].ShouldBe(solutionPath);
     }
+
+    [Fact]
+    public void AnySolutionPath_DoesNotRedirectStandardOutput()
+    {
+        // Arrange
+        string solutionPath = @"C:\projects\MyApp.sln";
+
+        // Act
+        System.Diagnostics.ProcessStartInfo result = DaemonProcess.BuildStartInfo(solutionPath);
+
+        // Assert
+        result.RedirectStandardOutput.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void AnySolutionPath_DoesNotRedirectStandardError()
+    {
+        // Arrange
+        string solutionPath = @"C:\projects\MyApp.sln";
+
+        // Act
+        System.Diagnostics.ProcessStartInfo result = DaemonProcess.BuildStartInfo(solutionPath);
+
+        // Assert
+        result.RedirectStandardError.ShouldBeFalse();
+    }
 }


### PR DESCRIPTION
## Summary
- `DaemonProcess.BuildStartInfo` set `RedirectStandardOutput = true` and `RedirectStandardError = true` but neither stream was ever read
- When the OS pipe buffer filled (~4 KB on Windows), the daemon blocked on its next write and hung indefinitely
- The daemon communicates via named pipe — these redirects served no purpose and are removed

## Test plan
- [ ] Regression tests added: `AnySolutionPath_DoesNotRedirectStandardOutput` and `AnySolutionPath_DoesNotRedirectStandardError` in `DaemonProcessTests/BuildStartInfo.cs`
- [ ] All 145 tests pass

Closes #20