### PR TITLE
Fix StopDaemon unconditional PID file cleanup

### DIFF
--- a/src/DaemonProcess.cs
+++ b/src/DaemonProcess.cs
@@ -92,21 +92,23 @@ public static class DaemonProcess
     public static void StopDaemon(string solutionPath)
     {
         int? pid = ReadPidFile(solutionPath);
+        if (!pid.HasValue)
+            return;
 
-        if (pid.HasValue)
+        try
         {
-            try
-            {
-                Process process = Process.GetProcessById(pid.Value);
-                if (IsDaemonProcess(process))
-                {
-                    process.Kill();
-                }
-            }
-            catch (ArgumentException)
-            {
-                // Process already exited — safe to ignore
-            }
+            Process process = Process.GetProcessById(pid.Value);
+            if (!IsDaemonProcess(process))
+                return;
+            process.Kill();
+        }
+        catch (ArgumentException)
+        {
+            // Process already exited before GetProcessById
+        }
+        catch (InvalidOperationException)
+        {
+            // Process exited between GetProcessById and Kill
         }
 
         CleanupPidFile(solutionPath);

--- a/tests/DaemonProcessTests/StopDaemon.cs
+++ b/tests/DaemonProcessTests/StopDaemon.cs
@@ -45,6 +45,23 @@ public sealed class StopDaemon : IDisposable
         Should.NotThrow(() => DaemonProcess.StopDaemon(_solutionPath));
     }
 
+    [Fact]
+    public void WhenPidBelongsToNonDaemonProcess_DoesNotDeletePidFile()
+    {
+        // Arrange
+        string pidFilePath = PipeProtocol.DerivePidFilePath(_solutionPath);
+        int explorerPid = System.Diagnostics.Process.GetProcessesByName("explorer")[0].Id;
+        File.WriteAllText(
+            pidFilePath,
+            explorerPid.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        // Act
+        DaemonProcess.StopDaemon(_solutionPath);
+
+        // Assert
+        File.Exists(pidFilePath).ShouldBeTrue();
+    }
+
     public void Dispose()
     {
         DaemonProcess.CleanupPidFile(_solutionPath);

--- a/tests/DaemonProcessTests/StopDaemon.cs
+++ b/tests/DaemonProcessTests/StopDaemon.cs
@@ -50,10 +50,11 @@ public sealed class StopDaemon : IDisposable
     {
         // Arrange
         string pidFilePath = PipeProtocol.DerivePidFilePath(_solutionPath);
-        int explorerPid = System.Diagnostics.Process.GetProcessesByName("explorer")[0].Id;
+        // The test runner process is guaranteed to not be named "roslyn-query",
+        // so IsDaemonProcess returns false — a portable substitute for any platform.
         File.WriteAllText(
             pidFilePath,
-            explorerPid.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            Environment.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
         // Act
         DaemonProcess.StopDaemon(_solutionPath);

--- a/tests/DaemonProcessTests/StopDaemon.cs
+++ b/tests/DaemonProcessTests/StopDaemon.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 using RoslynQuery;
 
 using Shouldly;
@@ -50,17 +52,34 @@ public sealed class StopDaemon : IDisposable
     {
         // Arrange
         string pidFilePath = PipeProtocol.DerivePidFilePath(_solutionPath);
-        // The test runner process is guaranteed to not be named "roslyn-query",
-        // so IsDaemonProcess returns false — a portable substitute for any platform.
-        File.WriteAllText(
-            pidFilePath,
-            Environment.ProcessId.ToString(System.Globalization.CultureInfo.InvariantCulture));
 
-        // Act
-        DaemonProcess.StopDaemon(_solutionPath);
+        // Spawn a short-lived process guaranteed to have a different name than "roslyn-query".
+        // IsDaemonProcess compares process names — this process will not match.
+        ProcessStartInfo startInfo = new()
+        {
+            FileName = OperatingSystem.IsWindows() ? "ping" : "sleep",
+            Arguments = OperatingSystem.IsWindows() ? "-n 30 127.0.0.1" : "30",
+            CreateNoWindow = true,
+            UseShellExecute = false,
+        };
 
-        // Assert
-        File.Exists(pidFilePath).ShouldBeTrue();
+        using Process dummy = Process.Start(startInfo)!;
+        try
+        {
+            File.WriteAllText(
+                pidFilePath,
+                dummy.Id.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+            // Act
+            DaemonProcess.StopDaemon(_solutionPath);
+
+            // Assert
+            File.Exists(pidFilePath).ShouldBeTrue();
+        }
+        finally
+        {
+            dummy.Kill();
+        }
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary

- `StopDaemon` now only deletes the PID file when the process is confirmed gone or killed
- If `IsDaemonProcess` returns false (PID recycled to a different process), the method returns early and leaves the PID file intact — the daemon may still be running
- Added `InvalidOperationException` catch for the case where the process exits between `GetProcessById` and `Kill`
- Fixed test to use the test-runner's own PID instead of `explorer` for cross-platform portability

## Test plan

- [ ] `WhenPidBelongsToNonDaemonProcess_DoesNotDeletePidFile` — PID file preserved on name mismatch
- [ ] All existing StopDaemon tests pass

Closes #23