### PR TITLE
Fix umask test isolation breaking SolutionDiscovery tests on Linux

### DIFF
--- a/src/DaemonServer.cs
+++ b/src/DaemonServer.cs
@@ -19,12 +19,14 @@ public static class DaemonServer
     private static extern uint umask(uint mask);
 #pragma warning restore CA5392
 
-    public static void ApplyUnixPipeUmask()
+    public static uint ApplyUnixPipeUmask()
     {
         if (!OperatingSystem.IsWindows())
         {
-            _ = umask(OwnerOnlyUmask);
+            return umask(OwnerOnlyUmask);
         }
+
+        return 0;
     }
 
     public static async Task RunAsync(

--- a/tests/DaemonServerTests/ApplyUnixPipeUmask.cs
+++ b/tests/DaemonServerTests/ApplyUnixPipeUmask.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 using RoslynQuery;
 
 using Shouldly;
@@ -6,6 +8,11 @@ namespace roslyn_query.Tests.DaemonServerTests;
 
 public sealed class ApplyUnixPipeUmask
 {
+#pragma warning disable CA5392 // P/Invoke targets libc — DefaultDllImportSearchPath does not apply
+    [DllImport("libc", SetLastError = false)]
+    private static extern uint umask(uint mask);
+#pragma warning restore CA5392
+
     [Fact]
     public void OnNonWindows_NewFileHasOwnerOnlyPermissions()
     {
@@ -18,17 +25,19 @@ public sealed class ApplyUnixPipeUmask
         string tempFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
 
         // Act
-        DaemonServer.ApplyUnixPipeUmask();
-        File.WriteAllText(tempFile, "test");
+        uint previous = DaemonServer.ApplyUnixPipeUmask();
 
         try
         {
+            File.WriteAllText(tempFile, "test");
+
             // Assert
             UnixFileMode mode = File.GetUnixFileMode(tempFile);
             mode.ShouldBe(UnixFileMode.UserRead | UnixFileMode.UserWrite);
         }
         finally
         {
+            _ = umask(previous);
             File.Delete(tempFile);
         }
     }


### PR DESCRIPTION
## Summary

- `ApplyUnixPipeUmask` test set process-wide umask to `0177` without restoring it, causing all subsequent temp-directory creation in the test process to produce mode-`600` directories (not traversable)
- `SolutionDiscoveryTests` create directories in `/tmp` and fail with `UnauthorizedAccessException: Permission denied`
- Fix: `ApplyUnixPipeUmask` now returns the previous umask; the test restores it in a `finally` block

## Test plan

- [ ] `SolutionDiscoveryTests` all pass on Linux CI
- [ ] `ApplyUnixPipeUmask` test still verifies the umask is applied correctly

Related: #34