### PR TITLE
Fix batch mode argument splitting to support double-quoted tokens

### DIFF
--- a/src/LineTokenizer.cs
+++ b/src/LineTokenizer.cs
@@ -1,0 +1,52 @@
+namespace RoslynQuery;
+
+public static class LineTokenizer
+{
+    public static string[] Tokenize(string line)
+    {
+        ArgumentNullException.ThrowIfNull(line);
+
+        List<string> tokens = [];
+        int i = 0;
+
+        while (i < line.Length)
+        {
+            if (line[i] == ' ')
+            {
+                i++;
+                continue;
+            }
+
+            if (line[i] == '"')
+            {
+                i++;
+                int start = i;
+
+                while (i < line.Length && line[i] != '"')
+                {
+                    i++;
+                }
+
+                tokens.Add(line[start..i]);
+
+                if (i < line.Length)
+                {
+                    i++;
+                }
+
+                continue;
+            }
+
+            int tokenStart = i;
+
+            while (i < line.Length && line[i] != ' ')
+            {
+                i++;
+            }
+
+            tokens.Add(line[tokenStart..i]);
+        }
+
+        return [.. tokens];
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -153,7 +153,7 @@ static async Task<int> RunBatch(string[] args)
 
         await Console.Out.WriteLineAsync($"=== {line} ===");
 
-        string[] subArgs = [.. line.Split(' ', StringSplitOptions.RemoveEmptyEntries)];
+        string[] subArgs = LineTokenizer.Tokenize(line);
         string[] fullArgs = [.. globalFlags, .. subArgs];
 
         int? daemonResult = await DaemonClient.TryExecuteAsync(

--- a/tests/LineTokenizerTests/Tokenize.cs
+++ b/tests/LineTokenizerTests/Tokenize.cs
@@ -1,0 +1,99 @@
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.LineTokenizerTests;
+
+public sealed class Tokenize
+{
+    [Fact]
+    public void QuotedArgWithSpaces_ReturnsSingleToken()
+    {
+        // Arrange
+        string line = @"find-refs ""My Class"" solution.sln";
+
+        // Act
+        string[] result = LineTokenizer.Tokenize(line);
+
+        // Assert
+        result.ShouldBe(["find-refs", "My Class", "solution.sln"]);
+    }
+
+    [Fact]
+    public void UnquotedArgs_ReturnsSameAsSplit()
+    {
+        // Arrange
+        string line = "find-refs MyClass solution.sln";
+
+        // Act
+        string[] result = LineTokenizer.Tokenize(line);
+
+        // Assert
+        result.ShouldBe(["find-refs", "MyClass", "solution.sln"]);
+    }
+
+    [Fact]
+    public void UnterminatedQuote_ConsumesToEndOfLine()
+    {
+        // Arrange
+        string line = @"find-refs ""My Class";
+
+        // Act
+        string[] result = LineTokenizer.Tokenize(line);
+
+        // Assert
+        result.ShouldBe(["find-refs", "My Class"]);
+    }
+
+    [Fact]
+    public void EmptyQuotedString_ReturnsEmptyStringToken()
+    {
+        // Arrange
+        string line = @"find-refs """"";
+
+        // Act
+        string[] result = LineTokenizer.Tokenize(line);
+
+        // Assert
+        result.ShouldBe(["find-refs", ""]);
+    }
+
+    [Fact]
+    public void MultipleConsecutiveSpaces_AreIgnored()
+    {
+        // Arrange
+        string line = "find-refs   MyClass   solution.sln";
+
+        // Act
+        string[] result = LineTokenizer.Tokenize(line);
+
+        // Assert
+        result.ShouldBe(["find-refs", "MyClass", "solution.sln"]);
+    }
+
+    [Fact]
+    public void EmptyString_ReturnsEmptyArray()
+    {
+        // Arrange
+        string line = "";
+
+        // Act
+        string[] result = LineTokenizer.Tokenize(line);
+
+        // Assert
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void WhitespaceOnly_ReturnsEmptyArray()
+    {
+        // Arrange
+        string line = "   ";
+
+        // Act
+        string[] result = LineTokenizer.Tokenize(line);
+
+        // Assert
+        result.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
- Replace plain `Split(' ')` in `Program.RunBatch` with a double-quote-aware state-machine tokeniser (`LineTokenizer`)
- Symbol names and paths containing spaces (e.g. `"My Class"`) now parse as a single token instead of being silently split into multiple malformed arguments

## Test plan
- [ ] `find-refs "My Class" solution.sln` → args `["find-refs", "My Class", "solution.sln"]`
- [ ] Unquoted args produce identical output to previous behaviour (no regression)
- [ ] Unterminated quote consumes to end of line as a single token
- [ ] Empty quoted string `""` is passed as an empty-string argument
- [ ] All scenarios covered by new tests in `tests/LineTokenizerTests/Tokenize.cs`

Closes #24