### PR TITLE
Add list-projects command

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,22 @@ class	MyApp.Orders.OrderAggregate	src/Orders/OrderAggregate.cs:5
 interface	MyApp.Orders.IOrderRepository	src/Orders/IOrderRepository.cs:3
 ```
 
+### list-projects
+
+All projects in the solution with name and file path.
+
+```bash
+roslyn-query list-projects
+```
+
+Output: `name\tpath` per project (path relative to solution directory by default; use `--absolute` for absolute paths).
+
+```text
+MyApp.Api	src/MyApp.Api/MyApp.Api.csproj
+MyApp.Domain	src/MyApp.Domain/MyApp.Domain.csproj
+MyApp.Tests	tests/MyApp.Tests/MyApp.Tests.csproj
+```
+
 ### describe
 
 Summary card for a type: kind, fully-qualified name, source location, base type, implemented interfaces, and member counts.

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -123,6 +123,7 @@ public static class CommandDispatcher
             "find-unused" => await FindUnused(showContext, basePath, effectiveContext),
             "list-members" => await ListMembers(rest, inherited, all, effectiveContext),
             "list-types" => await ListTypes(rest, showContext, basePath, effectiveContext),
+            "list-projects" => await ListProjects(basePath, effectiveContext),
             "describe" => await Describe(rest, basePath, effectiveContext),
             _ => await FailAsync($"Unknown command: {command}", effectiveContext.Stderr),
         };
@@ -167,6 +168,8 @@ public static class CommandDispatcher
             "  list-members <Type>        All members of a type (properties, methods, fields)");
         await stderr.WriteLineAsync(
             "  list-types <Namespace>     All types in a namespace (prefix match)");
+        await stderr.WriteLineAsync(
+            "  list-projects              All projects in the solution (name + path)");
         await stderr.WriteLineAsync(
             "  describe <Type>            Summary card: kind, location, base, interfaces, member counts");
         await stderr.WriteLineAsync(
@@ -1072,6 +1075,27 @@ public static class CommandDispatcher
         {
             await ctx.Stdout.WriteLineAsync(
                 $"members:    {string.Join(", ", parts)}");
+        }
+
+        return 0;
+    }
+
+    // -- list-projects ------------------------------------------------------------
+
+    private static async Task<int> ListProjects(string? basePath, CommandContext ctx)
+    {
+        foreach (Project project in ctx.Solution.Projects)
+        {
+            if (project.FilePath is null)
+            {
+                continue;
+            }
+
+            string path = basePath is not null
+                ? Path.GetRelativePath(basePath, project.FilePath)
+                : project.FilePath;
+
+            await ctx.Stdout.WriteLineAsync($"{project.Name}\t{path}");
         }
 
         return 0;

--- a/tests/CommandDispatcherTests/ListProjectsCommand.cs
+++ b/tests/CommandDispatcherTests/ListProjectsCommand.cs
@@ -1,0 +1,189 @@
+using Microsoft.CodeAnalysis;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.CommandDispatcherTests;
+
+public sealed class ListProjectsCommand
+{
+    [Fact]
+    public async Task WhenSolutionHasProjects_OutputsNameAndRelativePath()
+    {
+        // Arrange
+        string solutionDir = Path.Combine(Path.GetTempPath(), "mysln");
+        string projectPath = Path.Combine(solutionDir, "src", "MyApp", "MyApp.csproj");
+        Solution solution = CreateSolutionWithProject("MyApp", projectPath);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution, solutionDir);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["list-projects"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        string output = stdout.ToString().TrimEnd();
+        string expectedRelative = Path.Combine("src", "MyApp", "MyApp.csproj");
+        output.ShouldBe($"MyApp\t{expectedRelative}");
+    }
+
+    [Fact]
+    public async Task WhenAbsoluteFlag_OutputsAbsolutePath()
+    {
+        // Arrange
+        string solutionDir = Path.Combine(Path.GetTempPath(), "mysln");
+        string projectPath = Path.Combine(solutionDir, "src", "MyApp", "MyApp.csproj");
+        Solution solution = CreateSolutionWithProject("MyApp", projectPath);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution, solutionDir);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["list-projects", "--absolute"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        string output = stdout.ToString().TrimEnd();
+        output.ShouldBe($"MyApp\t{projectPath}");
+    }
+
+    [Fact]
+    public async Task WhenEmptySolution_OutputsNothing()
+    {
+        // Arrange
+        Solution solution = CreateEmptySolution();
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["list-projects"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        stdout.ToString().ShouldBeEmpty();
+        stderr.ToString().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenProjectHasNullFilePath_SkipsSilently()
+    {
+        // Arrange
+        Solution solution = CreateSolutionWithNullFilePath();
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["list-projects"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        stdout.ToString().ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenMultipleProjects_OutputsOneLinePerProject()
+    {
+        // Arrange
+        string solutionDir = Path.Combine(Path.GetTempPath(), "mysln");
+        string projectPathA = Path.Combine(solutionDir, "A", "A.csproj");
+        string projectPathB = Path.Combine(solutionDir, "B", "B.csproj");
+        Solution solution = CreateSolutionWithProjects(
+            ("ProjectA", projectPathA),
+            ("ProjectB", projectPathB));
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution, solutionDir);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["list-projects"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        string[] lines = stdout.ToString().TrimEnd().Split(Environment.NewLine);
+        lines.Length.ShouldBe(2);
+        lines.ShouldContain($"ProjectA\t{Path.Combine("A", "A.csproj")}");
+        lines.ShouldContain($"ProjectB\t{Path.Combine("B", "B.csproj")}");
+    }
+
+    private static Solution CreateSolutionWithProject(
+        string projectName,
+        string projectFilePath)
+    {
+        AdhocWorkspace workspace = new();
+        ProjectInfo projectInfo = ProjectInfo.Create(
+            ProjectId.CreateNewId(),
+            VersionStamp.Default,
+            projectName,
+            projectName,
+            LanguageNames.CSharp,
+            filePath: projectFilePath,
+            metadataReferences:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            ]);
+        Project project = workspace.AddProject(projectInfo);
+        return project.Solution;
+    }
+
+    private static Solution CreateSolutionWithProjects(
+        params (string Name, string FilePath)[] projects)
+    {
+        AdhocWorkspace workspace = new();
+        Solution solution = workspace.CurrentSolution;
+        foreach ((string name, string filePath) in projects)
+        {
+            ProjectInfo projectInfo = ProjectInfo.Create(
+                ProjectId.CreateNewId(),
+                VersionStamp.Default,
+                name,
+                name,
+                LanguageNames.CSharp,
+                filePath: filePath,
+                metadataReferences:
+                [
+                    MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+                ]);
+            solution = solution.AddProject(projectInfo);
+        }
+        workspace.TryApplyChanges(solution);
+        return workspace.CurrentSolution;
+    }
+
+    private static Solution CreateEmptySolution()
+    {
+        AdhocWorkspace workspace = new();
+        return workspace.CurrentSolution;
+    }
+
+    private static Solution CreateSolutionWithNullFilePath()
+    {
+        AdhocWorkspace workspace = new();
+        ProjectInfo projectInfo = ProjectInfo.Create(
+            ProjectId.CreateNewId(),
+            VersionStamp.Default,
+            "InMemoryProject",
+            "InMemoryProject",
+            LanguageNames.CSharp,
+            filePath: null,
+            metadataReferences:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            ]);
+        Project project = workspace.AddProject(projectInfo);
+        return project.Solution;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `list-projects` command that lists all projects in the loaded solution as `name\tpath`
- Paths are relative to the solution directory by default; `--absolute` emits absolute paths
- Projects with null `FilePath` (in-memory/ad-hoc) are silently skipped

## Test plan
- [ ] `ListProjectsCommand/WhenSolutionHasProjects_OutputsNameAndRelativePath`
- [ ] `ListProjectsCommand/WhenAbsoluteFlag_OutputsAbsolutePath`
- [ ] `ListProjectsCommand/WhenEmptySolution_OutputsNothing`
- [ ] `ListProjectsCommand/WhenProjectHasNullFilePath_SkipsSilently`
- [ ] `ListProjectsCommand/WhenMultipleProjects_OutputsOneLinePerProject`

Closes #11