### PR TITLE
Allow batch to read commands from a file argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,10 @@ All projects in the solution with name and file path.
 
 ```bash
 roslyn-query list-projects
+roslyn-query list-projects --absolute
 ```
 
-Output: `name\tpath` per project (path relative to solution directory by default; use `--absolute` for absolute paths).
+Output: `name\tpath` per project. Paths are relative to the solution directory by default; use `--absolute` for absolute paths.
 
 ```text
 MyApp.Api	src/MyApp.Api/MyApp.Api.csproj
@@ -255,9 +256,15 @@ Supports the `--absolute` flag to emit absolute file paths in the header line.
 
 ## Batch queries
 
-The `batch` command reads newline-delimited commands from stdin and runs each against the warm daemon, emitting results separated by `=== {command} ===` headers. This avoids multiple cold-start roundtrips when exploring a codebase.
+The `batch` command reads newline-delimited commands and runs each against the warm daemon, emitting results separated by `=== {command} ===` headers. This avoids multiple cold-start roundtrips when exploring a codebase.
+
+Commands can be read from a file or from stdin:
 
 ```bash
+# From a file
+roslyn-query batch queries.txt
+
+# From stdin
 printf 'find-refs OrderAggregate\nfind-callers PlaceOrder\nlist-members IOrderRepository\n' \
   | roslyn-query batch
 ```

--- a/src/BatchFileReader.cs
+++ b/src/BatchFileReader.cs
@@ -1,0 +1,31 @@
+namespace RoslynQuery;
+
+public static class BatchFileReader
+{
+    /// <summary>
+    /// Returns the file path argument from batch args, or null if stdin should be used.
+    /// A file arg is any non-flag, non-solution arg after "batch".
+    /// </summary>
+    public static string? ResolveFilePath(string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        foreach (string arg in args[1..])
+        {
+            if (arg.StartsWith('-'))
+            {
+                continue;
+            }
+
+            if (arg.EndsWith(".sln", StringComparison.OrdinalIgnoreCase)
+                || arg.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            return arg;
+        }
+
+        return null;
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -139,48 +139,67 @@ static async Task<int> RunBatch(string[] args)
         return 1;
     }
 
-    DaemonProcess.StartDaemon(solutionPath);
-
-    string? line;
-    int lastExitCode = 0;
-
-    while ((line = await Console.In.ReadLineAsync()) is not null)
+    string? filePath = BatchFileReader.ResolveFilePath(args);
+    if (filePath is not null && !File.Exists(filePath))
     {
-        if (string.IsNullOrWhiteSpace(line))
-        {
-            continue;
-        }
-
-        await Console.Out.WriteLineAsync($"=== {line} ===");
-
-        string[] subArgs = LineTokenizer.Tokenize(line);
-        string[] fullArgs = [.. globalFlags, .. subArgs];
-
-        int? daemonResult = await DaemonClient.TryExecuteAsync(
-            solutionPath,
-            fullArgs,
-            Console.Out,
-            Console.Error);
-
-        if (daemonResult.HasValue)
-        {
-            lastExitCode = daemonResult.Value;
-            continue;
-        }
-
-        daemonResult = await PollDaemon(solutionPath, fullArgs);
-        if (daemonResult.HasValue)
-        {
-            lastExitCode = daemonResult.Value;
-            continue;
-        }
-
-        await Console.Error.WriteLineAsync(
-            $"error: daemon unavailable for command: {line}");
-        lastExitCode = 1;
+        await Console.Error.WriteLineAsync($"error: file not found: {filePath}");
+        return 1;
     }
 
-    return lastExitCode;
+    DaemonProcess.StartDaemon(solutionPath);
+
+    StreamReader? fileReader = filePath is not null
+        ? new StreamReader(filePath, System.Text.Encoding.UTF8)
+        : null;
+    TextReader reader = fileReader ?? Console.In;
+
+    try
+    {
+        string? line;
+        int lastExitCode = 0;
+
+        while ((line = await reader.ReadLineAsync()) is not null)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                continue;
+            }
+
+            await Console.Out.WriteLineAsync($"=== {line} ===");
+
+            string[] subArgs = LineTokenizer.Tokenize(line);
+            string[] fullArgs = [.. globalFlags, .. subArgs];
+
+            int? daemonResult = await DaemonClient.TryExecuteAsync(
+                solutionPath,
+                fullArgs,
+                Console.Out,
+                Console.Error);
+
+            if (daemonResult.HasValue)
+            {
+                lastExitCode = daemonResult.Value;
+                continue;
+            }
+
+            daemonResult = await PollDaemon(solutionPath, fullArgs);
+            if (daemonResult.HasValue)
+            {
+                lastExitCode = daemonResult.Value;
+                continue;
+            }
+
+            await Console.Error.WriteLineAsync(
+                $"error: daemon unavailable for command: {line}");
+            lastExitCode = 1;
+        }
+
+        return lastExitCode;
+    }
+    finally
+    {
+        fileReader?.Dispose();
+    }
 }
 
 static async Task<int> RunDirect(string solutionPath, string[] args, bool quiet)

--- a/tests/BatchFileReaderTests/ResolveFilePath.cs
+++ b/tests/BatchFileReaderTests/ResolveFilePath.cs
@@ -1,0 +1,73 @@
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.BatchFileReaderTests;
+
+public sealed class ResolveFilePath
+{
+    [Fact]
+    public void WhenNoNonFlagArgs_ReturnsNull()
+    {
+        // Arrange
+        string[] args = ["batch", "--quiet"];
+
+        // Act
+        string? result = BatchFileReader.ResolveFilePath(args);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void WhenOnlySolutionArg_ReturnsNull()
+    {
+        // Arrange
+        string[] args = ["batch", "my.sln"];
+
+        // Act
+        string? result = BatchFileReader.ResolveFilePath(args);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void WhenFileArgPresent_ReturnsFilePath()
+    {
+        // Arrange
+        string[] args = ["batch", "queries.txt"];
+
+        // Act
+        string? result = BatchFileReader.ResolveFilePath(args);
+
+        // Assert
+        result.ShouldBe("queries.txt");
+    }
+
+    [Fact]
+    public void WhenFileArgAlongsideSolutionAndFlags_ReturnsFilePath()
+    {
+        // Arrange
+        string[] args = ["batch", "--quiet", "my.sln", "queries.txt"];
+
+        // Act
+        string? result = BatchFileReader.ResolveFilePath(args);
+
+        // Assert
+        result.ShouldBe("queries.txt");
+    }
+
+    [Fact]
+    public void WhenSlnxExtension_IsNotTreatedAsFileArg()
+    {
+        // Arrange
+        string[] args = ["batch", "my.slnx"];
+
+        // Act
+        string? result = BatchFileReader.ResolveFilePath(args);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- `roslyn-query batch queries.txt` reads commands from a file instead of stdin
- File is detected as any non-flag, non-solution positional arg after `batch`
- File not found returns `error: file not found: <path>` and exits with code 1
- Existing stdin behaviour is preserved when no file arg is provided
- File is streamed line-by-line with `ReadLineAsync` (no full-file load into memory)

## Test plan
- [ ] `BatchFileReaderTests/WhenNoNonFlagArgs_ReturnsNull`
- [ ] `BatchFileReaderTests/WhenOnlySolutionArg_ReturnsNull`
- [ ] `BatchFileReaderTests/WhenFileArgPresent_ReturnsFilePath`
- [ ] `BatchFileReaderTests/WhenFileArgAlongsideSolutionAndFlags_ReturnsFilePath`
- [ ] `BatchFileReaderTests/WhenSlnxExtension_IsNotTreatedAsFileArg`

Closes #13