### PR TITLE
Widen DeduplicateAndSort parameter to IEnumerable to eliminate intermediate list allocation

### DIFF
--- a/src/AttributeScanner.cs
+++ b/src/AttributeScanner.cs
@@ -32,7 +32,7 @@ public static class AttributeScanner
         return results;
     }
 
-    public static IReadOnlyList<AttributeMatch> DeduplicateAndSort(IReadOnlyList<AttributeMatch> results)
+    public static IReadOnlyList<AttributeMatch> DeduplicateAndSort(IEnumerable<AttributeMatch> results)
     {
         ArgumentNullException.ThrowIfNull(results);
 

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -683,7 +683,7 @@ public static class CommandDispatcher
                 }
             });
 
-        IReadOnlyList<AttributeMatch> results = AttributeScanner.DeduplicateAndSort([.. bag]);
+        IReadOnlyList<AttributeMatch> results = AttributeScanner.DeduplicateAndSort(bag);
 
         foreach (AttributeMatch result in results)
         {


### PR DESCRIPTION
## Summary
- Widened `AttributeScanner.DeduplicateAndSort` parameter from `IReadOnlyList<AttributeMatch>` to `IEnumerable<AttributeMatch>`
- Removed the `[.. bag]` spread at the call site in `CommandDispatcher.cs`, passing the `ConcurrentBag` directly
- Eliminates a throwaway list allocation on the hot path of every `find-attribute` run

## Test plan
- [ ] All 183 existing tests pass (`dotnet test`)
- [ ] Both test call sites in `ScanCompilation.cs` compile without changes (their argument types satisfy `IEnumerable<T>`)

Closes #28