### PR TITLE
feat: add .slnx solution file support

### DIFF
--- a/src/DaemonServer.cs
+++ b/src/DaemonServer.cs
@@ -39,7 +39,7 @@ public static class DaemonServer
             DaemonProcess.CleanupPidFile(solutionPath);
 
         using MSBuildWorkspace workspace = MSBuildWorkspace.Create();
-        await workspace.OpenSolutionAsync(solutionPath, cancellationToken: cancellationToken);
+        await SolutionLoader.LoadAsync(workspace, solutionPath, cancellationToken);
         ReloadState reloadState = new(
             workspace.CurrentSolution,
             File.GetLastWriteTimeUtc(solutionPath));
@@ -86,9 +86,10 @@ public static class DaemonServer
                                 {
                                     try
                                     {
-                                        await workspace.OpenSolutionAsync(
+                                        await SolutionLoader.LoadAsync(
+                                            workspace,
                                             solutionPath,
-                                            cancellationToken: cancellationToken);
+                                            cancellationToken);
                                         reloadState.CompleteReload(
                                             workspace.CurrentSolution,
                                             File.GetLastWriteTimeUtc(solutionPath));

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -244,6 +244,6 @@ static async Task<MSBuildWorkspace> OpenWorkspace(string solutionPath, bool quie
             Console.Error.WriteLine($"workspace warning: {e.Diagnostic.Message}");
         }
     };
-    await workspace.OpenSolutionAsync(solutionPath);
+    await SolutionLoader.LoadAsync(workspace, solutionPath);
     return workspace;
 }

--- a/src/SlnxReader.cs
+++ b/src/SlnxReader.cs
@@ -1,0 +1,34 @@
+using System.Xml.Linq;
+
+namespace RoslynQuery;
+
+public static class SlnxReader
+{
+    public static IReadOnlyList<string> ReadProjectPaths(string slnxPath)
+    {
+        string dir = Path.GetDirectoryName(slnxPath) ?? "";
+        XDocument doc = XDocument.Load(slnxPath);
+        List<string> paths = [];
+        CollectPaths(doc.Root!, dir, paths);
+        return paths;
+    }
+
+    private static void CollectPaths(XElement element, string baseDir, List<string> paths)
+    {
+        foreach (XElement child in element.Elements())
+        {
+            if (child.Name.LocalName == "Project")
+            {
+                string? relativePath = (string?)child.Attribute("Path");
+                if (relativePath is not null)
+                {
+                    paths.Add(Path.GetFullPath(Path.Combine(baseDir, relativePath)));
+                }
+            }
+            else if (child.Name.LocalName == "Folder")
+            {
+                CollectPaths(child, baseDir, paths);
+            }
+        }
+    }
+}

--- a/src/SolutionLoader.cs
+++ b/src/SolutionLoader.cs
@@ -1,0 +1,34 @@
+using Microsoft.CodeAnalysis.MSBuild;
+
+namespace RoslynQuery;
+
+public static class SolutionLoader
+{
+    public static async Task LoadAsync(
+        MSBuildWorkspace workspace,
+        string solutionPath,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(workspace);
+        ArgumentNullException.ThrowIfNull(solutionPath);
+        if (solutionPath.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
+        {
+            await LoadSlnxAsync(workspace, solutionPath, cancellationToken);
+            return;
+        }
+
+        await workspace.OpenSolutionAsync(solutionPath, cancellationToken: cancellationToken);
+    }
+
+    private static async Task LoadSlnxAsync(
+        MSBuildWorkspace workspace,
+        string slnxPath,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<string> projectPaths = SlnxReader.ReadProjectPaths(slnxPath);
+        foreach (string projectPath in projectPaths)
+        {
+            await workspace.OpenProjectAsync(projectPath, cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/tests/SlnxReaderTests/ReadProjectPaths.cs
+++ b/tests/SlnxReaderTests/ReadProjectPaths.cs
@@ -1,0 +1,101 @@
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.SlnxReaderTests;
+
+public sealed class ReadProjectPaths
+{
+    [Fact]
+    public void WhenProjectsAtRoot_ReturnsAbsolutePaths()
+    {
+        // Arrange
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        string slnxPath = Path.Combine(dir, "solution.slnx");
+        File.WriteAllText(slnxPath, """
+            <Solution>
+              <Project Path="src/Alpha/Alpha.csproj" />
+              <Project Path="src/Beta/Beta.csproj" />
+            </Solution>
+            """);
+
+        try
+        {
+            // Act
+            IReadOnlyList<string> result = SlnxReader.ReadProjectPaths(slnxPath);
+
+            // Assert
+            result.ShouldBe(
+            [
+                Path.GetFullPath(Path.Combine(dir, "src/Alpha/Alpha.csproj")),
+                Path.GetFullPath(Path.Combine(dir, "src/Beta/Beta.csproj")),
+            ]);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenProjectsInNestedFolders_ReturnsAllPaths()
+    {
+        // Arrange
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        string slnxPath = Path.Combine(dir, "solution.slnx");
+        File.WriteAllText(slnxPath, """
+            <Solution>
+              <Project Path="src/App/App.csproj" />
+              <Folder Name="Tests">
+                <Project Path="tests/App.Tests/App.Tests.csproj" />
+                <Folder Name="Integration">
+                  <Project Path="tests/App.IntegrationTests/App.IntegrationTests.csproj" />
+                </Folder>
+              </Folder>
+            </Solution>
+            """);
+
+        try
+        {
+            // Act
+            IReadOnlyList<string> result = SlnxReader.ReadProjectPaths(slnxPath);
+
+            // Assert
+            result.ShouldBe(
+            [
+                Path.GetFullPath(Path.Combine(dir, "src/App/App.csproj")),
+                Path.GetFullPath(Path.Combine(dir, "tests/App.Tests/App.Tests.csproj")),
+                Path.GetFullPath(Path.Combine(dir, "tests/App.IntegrationTests/App.IntegrationTests.csproj")),
+            ]);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenNoProjects_ReturnsEmpty()
+    {
+        // Arrange
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(dir);
+        string slnxPath = Path.Combine(dir, "solution.slnx");
+        File.WriteAllText(slnxPath, "<Solution></Solution>");
+
+        try
+        {
+            // Act
+            IReadOnlyList<string> result = SlnxReader.ReadProjectPaths(slnxPath);
+
+            // Assert
+            result.ShouldBeEmpty();
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `MSBuildWorkspace.OpenSolutionAsync` routes through `Microsoft.Build.Construction.SolutionFile.Parse()`, which only understands the legacy line-based `.sln` format and throws on `.slnx`
- Added `SlnxReader` to parse the XML-based `.slnx` format and extract project paths
- Added `SolutionLoader` to dispatch on extension: `.slnx` loads projects individually via `OpenProjectAsync`; `.sln` uses the existing `OpenSolutionAsync` path
- Updated `DaemonServer` and `Program` to use `SolutionLoader.LoadAsync`

## Test plan

- [ ] `SlnxReader` unit tests cover root-level projects, nested folders, and empty solution
- [ ] `dotnet test` — 186/186 passing
- [ ] Manual: run `roslyn-query find-refs` against a `.slnx` solution to confirm workspace loads correctly