### PR TITLE
fix: dispose Process handle and catch Win32Exception in StopDaemon

### DIFF
--- a/src/DaemonProcess.cs
+++ b/src/DaemonProcess.cs
@@ -97,7 +97,7 @@ public static class DaemonProcess
 
         try
         {
-            Process process = Process.GetProcessById(pid.Value);
+            using Process process = Process.GetProcessById(pid.Value);
             if (!IsDaemonProcess(process))
                 return;
             process.Kill();
@@ -109,6 +109,12 @@ public static class DaemonProcess
         catch (InvalidOperationException)
         {
             // Process exited between GetProcessById and Kill
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // Kill() was denied (e.g. access denied). Daemon is still running —
+            // leave the PID file intact so future stop attempts can retry.
+            return;
         }
 
         CleanupPidFile(solutionPath);


### PR DESCRIPTION
## Summary

- `Process.GetProcessById()` returned an undisposed `Process` handle — wrapped in `using` to close it after `Kill()`
- `Process.Kill()` can throw `Win32Exception` (access denied) on Windows, which propagated uncaught and skipped `CleanupPidFile`. Added a `catch` that returns early, leaving the PID file intact since the daemon is still running in that case

## Test plan

- [ ] Existing `StopDaemon` tests cover the main paths (bogus PID, no PID file, non-daemon process) — all 186 tests pass