### PR TITLE
fix: wait for daemon process to exit in StopDaemon

### DIFF
--- a/reinstall.sh
+++ b/reinstall.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Stopping daemon..."
+roslyn-query daemon stop 2>/dev/null || true
+
+echo "Killing any remaining roslyn-query processes..."
+powershell -NoProfile -Command "
+    Get-Process roslyn-query -ErrorAction SilentlyContinue | ForEach-Object {
+        \$_.Kill()
+        \$null = \$_.WaitForExit(5000)
+    }
+"
+
+echo "Uninstalling..."
+dotnet tool uninstall -g roslyn-query 2>/dev/null || true
+
+echo "Packing..."
+dotnet pack "$SCRIPT_DIR/src/roslyn-query.csproj" -c Release -o "$SCRIPT_DIR/bin/nupkg" --nologo -v q
+
+echo "Installing..."
+dotnet tool install -g roslyn-query --add-source "$SCRIPT_DIR/bin/nupkg"
+
+echo "Done. Testing..."
+roslyn-query list-projects

--- a/src/DaemonProcess.cs
+++ b/src/DaemonProcess.cs
@@ -101,6 +101,7 @@ public static class DaemonProcess
             if (!IsDaemonProcess(process))
                 return;
             process.Kill();
+            process.WaitForExit();
         }
         catch (ArgumentException)
         {


### PR DESCRIPTION
## Summary

- `StopDaemon` now calls `process.WaitForExit()` after `process.Kill()` so the method doesn't return until the process has actually terminated
- On Windows, `Kill()` is asynchronous — without the wait, the process was still alive (holding DLL file locks) when `dotnet tool uninstall` ran, causing an access-denied failure
- Adds `reinstall.sh` to automate the full pack → uninstall → reinstall cycle

## Test plan

- [ ] Run `roslyn-query list-projects` to start the daemon
- [ ] Run `roslyn-query daemon stop` and confirm no `roslyn-query.exe` process remains in Task Manager
- [ ] Run `bash reinstall.sh` and confirm it completes without errors