### PR TITLE
fix: skip already-loaded projects when opening .slnx solution

### DIFF
--- a/src/SolutionLoader.cs
+++ b/src/SolutionLoader.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
 
 namespace RoslynQuery;
@@ -20,15 +21,36 @@ public static class SolutionLoader
         await workspace.OpenSolutionAsync(solutionPath, cancellationToken: cancellationToken);
     }
 
+    public static async Task LoadProjectsAsync(
+        Workspace workspace,
+        IReadOnlyList<string> projectPaths,
+        Func<string, CancellationToken, Task> openProject,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(workspace);
+        ArgumentNullException.ThrowIfNull(projectPaths);
+        ArgumentNullException.ThrowIfNull(openProject);
+        foreach (string projectPath in projectPaths)
+        {
+            bool alreadyLoaded = workspace.CurrentSolution.Projects
+                .Any(p => string.Equals(p.FilePath, projectPath, StringComparison.OrdinalIgnoreCase));
+            if (!alreadyLoaded)
+            {
+                await openProject(projectPath, cancellationToken);
+            }
+        }
+    }
+
     private static async Task LoadSlnxAsync(
         MSBuildWorkspace workspace,
         string slnxPath,
         CancellationToken cancellationToken)
     {
         IReadOnlyList<string> projectPaths = SlnxReader.ReadProjectPaths(slnxPath);
-        foreach (string projectPath in projectPaths)
-        {
-            await workspace.OpenProjectAsync(projectPath, cancellationToken: cancellationToken);
-        }
+        await LoadProjectsAsync(
+            workspace,
+            projectPaths,
+            (path, ct) => workspace.OpenProjectAsync(path, cancellationToken: ct),
+            cancellationToken);
     }
 }

--- a/tests/SolutionLoaderTests/LoadProjectsAsync.cs
+++ b/tests/SolutionLoaderTests/LoadProjectsAsync.cs
@@ -1,0 +1,123 @@
+using Microsoft.CodeAnalysis;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.SolutionLoaderTests;
+
+public sealed class LoadProjectsAsync
+{
+    [Fact]
+    public async Task WhenProjectNotInWorkspace_OpensIt()
+    {
+        // Arrange
+        string projectPath = @"C:\solution\src\Alpha\Alpha.csproj";
+        using AdhocWorkspace workspace = new();
+        List<string> opened = [];
+
+        // Act
+        await SolutionLoader.LoadProjectsAsync(
+            workspace,
+            [projectPath],
+            (path, _) => { opened.Add(path); return Task.CompletedTask; },
+            CancellationToken.None);
+
+        // Assert
+        opened.ShouldBe([projectPath]);
+    }
+
+    [Fact]
+    public async Task WhenProjectAlreadyInWorkspace_SkipsIt()
+    {
+        // Arrange
+        string projectPath = @"C:\solution\src\Alpha\Alpha.csproj";
+        using AdhocWorkspace workspace = new();
+        workspace.AddProject(ProjectInfo.Create(
+            ProjectId.CreateNewId(),
+            VersionStamp.Create(),
+            "Alpha",
+            "Alpha",
+            LanguageNames.CSharp,
+            filePath: projectPath));
+        List<string> opened = [];
+
+        // Act
+        await SolutionLoader.LoadProjectsAsync(
+            workspace,
+            [projectPath],
+            (path, _) => { opened.Add(path); return Task.CompletedTask; },
+            CancellationToken.None);
+
+        // Assert
+        opened.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task WhenTransitiveDependencyAlsoListedDirectly_SkipsSecondOpen()
+    {
+        // This is the bug scenario: Beta is opened first and its open-delegate
+        // simulates Roslyn loading Alpha as a project reference. When Alpha is
+        // then encountered directly in the slnx list it must be skipped.
+
+        // Arrange
+        string alphaPath = @"C:\solution\src\Alpha\Alpha.csproj";
+        string betaPath = @"C:\solution\src\Beta\Beta.csproj";
+        using AdhocWorkspace workspace = new();
+        List<string> opened = [];
+
+        Task OpenProject(string path, CancellationToken _)
+        {
+            opened.Add(path);
+            if (path == betaPath)
+            {
+                // Simulate Roslyn adding Alpha as Beta's transitive project reference.
+                workspace.AddProject(ProjectInfo.Create(
+                    ProjectId.CreateNewId(),
+                    VersionStamp.Create(),
+                    "Alpha",
+                    "Alpha",
+                    LanguageNames.CSharp,
+                    filePath: alphaPath));
+            }
+            return Task.CompletedTask;
+        }
+
+        // Act — slnx lists Beta first, then Alpha
+        await SolutionLoader.LoadProjectsAsync(
+            workspace,
+            [betaPath, alphaPath],
+            OpenProject,
+            CancellationToken.None);
+
+        // Assert — Alpha was not opened a second time
+        opened.ShouldBe([betaPath]);
+    }
+
+    [Fact]
+    public async Task PathComparisonIsCaseInsensitive()
+    {
+        // Arrange
+        string projectPath = @"C:\Solution\Src\Alpha\Alpha.csproj";
+        string projectPathLower = @"C:\solution\src\alpha\alpha.csproj";
+        using AdhocWorkspace workspace = new();
+        workspace.AddProject(ProjectInfo.Create(
+            ProjectId.CreateNewId(),
+            VersionStamp.Create(),
+            "Alpha",
+            "Alpha",
+            LanguageNames.CSharp,
+            filePath: projectPath));
+        List<string> opened = [];
+
+        // Act
+        await SolutionLoader.LoadProjectsAsync(
+            workspace,
+            [projectPathLower],
+            (path, _) => { opened.Add(path); return Task.CompletedTask; },
+            CancellationToken.None);
+
+        // Assert
+        opened.ShouldBeEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- `OpenProjectAsync` loads transitive project references automatically. If a referenced project is also listed directly in the `.slnx`, the second `OpenProjectAsync` call throws `ArgumentException: 'X' is already part of the workspace`.
- Fix: check `workspace.CurrentSolution.Projects` by file path before each `OpenProjectAsync` call and skip projects already present.
- Extracted the dedup loop into a public `LoadProjectsAsync` overload (accepts `Workspace` + open-project delegate) to make the logic unit-testable without real MSBuild.

## Test plan

- [ ] `WhenProjectNotInWorkspace_OpensIt` — baseline: unknown project gets opened
- [ ] `WhenProjectAlreadyInWorkspace_SkipsIt` — already-loaded project is skipped
- [ ] `WhenTransitiveDependencyAlsoListedDirectly_SkipsSecondOpen` — the exact bug: opening Beta causes Alpha to appear in the workspace, then Alpha's direct entry in the slnx list is skipped
- [ ] `PathComparisonIsCaseInsensitive` — `OrdinalIgnoreCase` guard works
- [ ] Full suite: 190/190 passing