### PR TITLE
fix: prevent reinstall.sh from failing when no roslyn-query processes are running

### DIFF
--- a/reinstall.sh
+++ b/reinstall.sh
@@ -12,7 +12,8 @@ powershell -NoProfile -Command "
         \$_.Kill()
         \$null = \$_.WaitForExit(5000)
     }
-"
+    exit 0
+" || true
 
 echo "Uninstalling..."
 dotnet tool uninstall -g roslyn-query 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Add `exit 0` to the PowerShell block so it doesn't return exit code 1 when no `roslyn-query` processes are found
- Add `|| true` as a belt-and-suspenders guard so `set -e` never trips on this step