### PR TITLE
fix: support fully-qualified symbol names in find-refs, find-callers, find-overrides

### DIFF
--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -331,9 +331,9 @@ public static class CommandDispatcher
 
     internal static async Task<List<ISymbol>> FindSymbolsByName(Solution solution, string symbolName)
     {
-        string[] parts = symbolName.Split('.', 2);
-        string memberName = parts[^1];
-        string? typeName = parts.Length > 1 ? parts[0] : null;
+        int lastDot = symbolName.LastIndexOf('.');
+        string memberName = lastDot >= 0 ? symbolName[(lastDot + 1)..] : symbolName;
+        string? qualifier = lastDot >= 0 ? symbolName[..lastDot] : null;
 
         List<ISymbol> found = [];
         HashSet<ISymbol> seen = new(SymbolEqualityComparer.Default);
@@ -347,7 +347,7 @@ public static class CommandDispatcher
 
             foreach (ISymbol symbol in candidates)
             {
-                if (typeName is not null && symbol.ContainingType?.Name != typeName)
+                if (qualifier is not null && !MatchesQualifier(symbol, qualifier))
                 {
                     continue;
                 }
@@ -360,6 +360,18 @@ public static class CommandDispatcher
         }
 
         return found;
+    }
+
+    private static bool MatchesQualifier(ISymbol symbol, string qualifier)
+    {
+        if (!qualifier.Contains('.', StringComparison.Ordinal))
+        {
+            return symbol.ContainingType?.Name == qualifier;
+        }
+
+        string containerFqn = symbol.ContainingSymbol?.ToDisplayString() ?? string.Empty;
+        return containerFqn == qualifier
+            || containerFqn.EndsWith($".{qualifier}", StringComparison.Ordinal);
     }
 
     internal static IEnumerable<INamedTypeSymbol> GetAllTypes(INamespaceSymbol ns)

--- a/tests/CommandDispatcherTests/FindSymbolsByName.cs
+++ b/tests/CommandDispatcherTests/FindSymbolsByName.cs
@@ -1,0 +1,70 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.CommandDispatcherTests;
+
+public sealed class FindSymbolsByName
+{
+    [Fact]
+    public async Task WhenMethodHasQualifiedReturnType_FindsByFqn()
+    {
+        // Arrange
+        string source = @"
+using System.Collections.Generic;
+
+namespace MyApp.Services
+{
+    public class OrderService
+    {
+        public List<int> GetItems() { return new List<int>(); }
+    }
+
+    public class Consumer
+    {
+        public void Use()
+        {
+            var svc = new OrderService();
+            svc.GetItems();
+        }
+    }
+}";
+        Solution solution = CreateSolution(source);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["find-refs", "MyApp.Services.OrderService.GetItems"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        stdout.ToString().ShouldNotBeEmpty();
+    }
+
+    private static Solution CreateSolution(string source)
+    {
+        AdhocWorkspace workspace = new();
+        ProjectInfo projectInfo = ProjectInfo.Create(
+            ProjectId.CreateNewId(),
+            VersionStamp.Default,
+            "TestProject",
+            "TestProject",
+            LanguageNames.CSharp,
+            metadataReferences:
+            [
+                MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            ]);
+        Project project = workspace.AddProject(projectInfo);
+        Document document = workspace.AddDocument(
+            project.Id,
+            "Test.cs",
+            SourceText.From(source));
+        return document.Project.Solution;
+    }
+}


### PR DESCRIPTION
## Summary
- `FindSymbolsByName` used `Split('.', 2)` which split on the first dot, so `A.B.C.TypeName` was misinterpreted as `typeName="A"`, `memberName="B.C.TypeName"` — producing "Symbol not found" for any FQN input
- Fixed by using `LastIndexOf('.')` to extract the simple name and qualifier, then matching via `symbol.ContainingSymbol.ToDisplayString()` which is immune to return-type dots in method display strings

## Test plan
- [ ] `find-refs "A.B.C.TypeName"` returns references when type exists in namespace `A.B.C`
- [ ] `find-refs "A.B.C.TypeName.Member"` returns references when member exists
- [ ] `find-callers` and `find-overrides` work with FQN input
- [ ] Simple name (`TypeName`) and `TypeName.Member` formats still work (regression)
- [ ] Disambiguation: same type name in two namespaces — FQN qualifier picks the correct one
- [ ] Unknown symbol name returns empty (not an error)
- [ ] Method with qualified return type (`List<T>`) found correctly by FQN

Closes #50