### PR TITLE
fix: resolve symbols defined in NuGet packages

### DIFF
--- a/src/AttributeScanner.cs
+++ b/src/AttributeScanner.cs
@@ -83,33 +83,5 @@ public static class AttributeScanner
     }
 
     private static IEnumerable<INamedTypeSymbol> GetAllTypes(INamespaceSymbol ns)
-    {
-        foreach (INamedTypeSymbol type in ns.GetTypeMembers())
-        {
-            yield return type;
-            foreach (INamedTypeSymbol nested in GetNestedTypes(type))
-            {
-                yield return nested;
-            }
-        }
-        foreach (INamespaceSymbol childNs in ns.GetNamespaceMembers())
-        {
-            foreach (INamedTypeSymbol type in GetAllTypes(childNs))
-            {
-                yield return type;
-            }
-        }
-    }
-
-    private static IEnumerable<INamedTypeSymbol> GetNestedTypes(INamedTypeSymbol type)
-    {
-        foreach (INamedTypeSymbol nested in type.GetTypeMembers())
-        {
-            yield return nested;
-            foreach (INamedTypeSymbol n in GetNestedTypes(nested))
-            {
-                yield return n;
-            }
-        }
-    }
+        => NamespaceWalker.GetAllTypes(ns);
 }

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -394,6 +394,13 @@ public static class CommandDispatcher
         string typeName)
     {
         Compilation[] compilations = await LoadCompilationsAsync(solution);
+        return FindTypeByName(compilations, typeName);
+    }
+
+    internal static INamedTypeSymbol? FindTypeByName(
+        Compilation[] compilations,
+        string typeName)
+    {
         List<INamedTypeSymbol> targets = CollectTypeTargets(compilations, typeName);
         return targets.Count > 0 ? targets[0] : null;
     }
@@ -527,7 +534,8 @@ public static class CommandDispatcher
         string typeName = args[0];
         Solution solution = ctx.Solution;
 
-        INamedTypeSymbol? target = await FindTypeByName(solution, typeName);
+        Compilation[] compilations = await LoadCompilationsAsync(solution);
+        INamedTypeSymbol? target = FindTypeByName(compilations, typeName);
         if (target is null)
         {
             return await FailAsync($"Type not found: {typeName}", ctx.Stderr);
@@ -568,7 +576,8 @@ public static class CommandDispatcher
         string typeName = args[0];
         Solution solution = ctx.Solution;
 
-        INamedTypeSymbol? target = await FindTypeByName(solution, typeName);
+        Compilation[] compilations = await LoadCompilationsAsync(solution);
+        INamedTypeSymbol? target = FindTypeByName(compilations, typeName);
         if (target is null)
         {
             return await FailAsync($"Type not found: {typeName}", ctx.Stderr);
@@ -925,7 +934,8 @@ public static class CommandDispatcher
         string typeName = args[0];
         Solution solution = ctx.Solution;
 
-        INamedTypeSymbol? target = await FindTypeByName(solution, typeName);
+        Compilation[] compilations = await LoadCompilationsAsync(solution);
+        INamedTypeSymbol? target = FindTypeByName(compilations, typeName);
         if (target is null)
         {
             return await FailAsync($"Type not found: {typeName}", ctx.Stderr);
@@ -1025,19 +1035,8 @@ public static class CommandDispatcher
         string typeName = args[0];
         Solution solution = ctx.Solution;
 
-        List<INamedTypeSymbol> matches = [];
-        HashSet<INamedTypeSymbol> seen = new(SymbolEqualityComparer.Default);
-
         Compilation[] compilations = await LoadCompilationsAsync(solution);
-        foreach (Compilation compilation in compilations)
-        {
-            IEnumerable<INamedTypeSymbol> candidates = compilation
-                .GetSymbolsWithName(typeName, SymbolFilter.Type)
-                .OfType<INamedTypeSymbol>()
-                .Where(t => t.Locations.Any(l => l.IsInSource));
-
-            matches.AddRange(candidates.Where(candidate => seen.Add(candidate)));
-        }
+        List<INamedTypeSymbol> matches = CollectTypeTargets(compilations, typeName);
 
         if (matches.Count == 0)
         {

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -359,6 +359,15 @@ public static class CommandDispatcher
             }
         }
 
+        if (found.Count == 0)
+        {
+            IReadOnlyList<ISymbol> metadataMembers = MetadataTypeResolver.FindMetadataMembers(
+                compilations,
+                memberName,
+                qualifier);
+            found.AddRange(metadataMembers);
+        }
+
         return found;
     }
 
@@ -410,19 +419,49 @@ public static class CommandDispatcher
         string typeName)
     {
         Compilation[] compilations = await LoadCompilationsAsync(solution);
+        List<INamedTypeSymbol> targets = CollectTypeTargets(compilations, typeName);
+        return targets.Count > 0 ? targets[0] : null;
+    }
+
+    private static List<INamedTypeSymbol> CollectTypeTargets(
+        Compilation[] compilations,
+        string typeName)
+    {
+        int lastDot = typeName.LastIndexOf('.');
+        string simpleName = lastDot >= 0 ? typeName[(lastDot + 1)..] : typeName;
+
+        HashSet<INamedTypeSymbol> seen = new(SymbolEqualityComparer.Default);
+        List<INamedTypeSymbol> sourceTargets = [];
+
         foreach (Compilation compilation in compilations)
         {
-            INamedTypeSymbol? target = compilation
-                .GetSymbolsWithName(typeName, SymbolFilter.Type)
+            IEnumerable<INamedTypeSymbol> candidates = compilation
+                .GetSymbolsWithName(simpleName, SymbolFilter.Type)
                 .OfType<INamedTypeSymbol>()
-                .FirstOrDefault(t => t.Locations.Any(l => l.IsInSource));
+                .Where(t => t.Locations.Any(l => l.IsInSource));
 
-            if (target is not null)
+            foreach (INamedTypeSymbol t in candidates)
             {
-                return target;
+                if (lastDot >= 0 && !MatchesQualifier(t, typeName[..lastDot]))
+                {
+                    continue;
+                }
+
+                if (seen.Add(t))
+                {
+                    sourceTargets.Add(t);
+                }
             }
         }
-        return null;
+
+        if (sourceTargets.Count > 0)
+        {
+            return sourceTargets;
+        }
+
+        return MetadataTypeResolver
+            .FindMetadataTypes(compilations, typeName)
+            .ToList();
     }
 
     // -- find-refs ----------------------------------------------------------------
@@ -959,38 +998,25 @@ public static class CommandDispatcher
         string typeName = args[0];
         Solution solution = ctx.Solution;
 
-        INamedTypeSymbol? target = await FindTypeByName(solution, typeName);
-        List<INamedTypeSymbol> targets;
+        Compilation[] compilations = await LoadCompilationsAsync(solution);
+        List<INamedTypeSymbol> targets = CollectTypeTargets(compilations, typeName);
 
-        if (target is not null)
+        if (targets.Count == 0)
         {
-            targets = [target];
+            return await FailAsync($"Type not found: {typeName}", ctx.Stderr);
         }
-        else
+
+        if (targets.Count > 1 && !all)
         {
-            Compilation[] compilations = await LoadCompilationsAsync(solution);
-
-            targets = MetadataTypeResolver
-                .FindMetadataTypes(compilations, typeName)
-                .ToList();
-
-            if (targets.Count == 0)
+            await ctx.Stderr.WriteLineAsync(
+                $"Ambiguous '{typeName}' — {targets.Count} matches:");
+            foreach (INamedTypeSymbol t in targets)
             {
-                return await FailAsync($"Type not found: {typeName}", ctx.Stderr);
+                await ctx.Stderr.WriteLineAsync($"  {t.ToDisplayString()}");
             }
-
-            if (targets.Count > 1 && !all)
-            {
-                await ctx.Stderr.WriteLineAsync(
-                    $"Ambiguous '{typeName}' — {targets.Count} matches:");
-                foreach (INamedTypeSymbol t in targets)
-                {
-                    await ctx.Stderr.WriteLineAsync($"  {t.ToDisplayString()}");
-                }
-                await ctx.Stderr.WriteLineAsync(
-                    "Use a fully-qualified name to disambiguate, or pass --all.");
-                return 1;
-            }
+            await ctx.Stderr.WriteLineAsync(
+                "Use a fully-qualified name to disambiguate, or pass --all.");
+            return 1;
         }
 
         bool multipleTypes = targets.Count > 1;

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -384,35 +384,10 @@ public static class CommandDispatcher
     }
 
     internal static IEnumerable<INamedTypeSymbol> GetAllTypes(INamespaceSymbol ns)
-    {
-        foreach (INamedTypeSymbol type in ns.GetTypeMembers())
-        {
-            yield return type;
-            foreach (INamedTypeSymbol nested in GetNestedTypes(type))
-            {
-                yield return nested;
-            }
-        }
-        foreach (INamespaceSymbol childNs in ns.GetNamespaceMembers())
-        {
-            foreach (INamedTypeSymbol type in GetAllTypes(childNs))
-            {
-                yield return type;
-            }
-        }
-    }
+        => NamespaceWalker.GetAllTypes(ns);
 
     internal static IEnumerable<INamedTypeSymbol> GetNestedTypes(INamedTypeSymbol type)
-    {
-        foreach (INamedTypeSymbol nested in type.GetTypeMembers())
-        {
-            yield return nested;
-            foreach (INamedTypeSymbol n in GetNestedTypes(nested))
-            {
-                yield return n;
-            }
-        }
-    }
+        => NamespaceWalker.GetNestedTypes(type);
 
     internal static async Task<INamedTypeSymbol?> FindTypeByName(
         Solution solution,

--- a/src/MetadataTypeResolver.cs
+++ b/src/MetadataTypeResolver.cs
@@ -15,6 +15,8 @@ public static class MetadataTypeResolver
         HashSet<string> seen = new();
         List<ISymbol> results = [];
 
+        string? dottedQualifier = qualifier is not null ? $".{qualifier}" : null;
+
         foreach (Compilation compilation in compilations)
         {
             foreach (MetadataReference reference in compilation.References)
@@ -28,7 +30,8 @@ public static class MetadataTypeResolver
                 foreach (ISymbol member in FindMembersInNamespace(
                     assembly.GlobalNamespace,
                     memberName,
-                    qualifier))
+                    qualifier,
+                    dottedQualifier))
                 {
                     string key = member.ToDisplayString();
                     if (seen.Add(key))
@@ -45,18 +48,19 @@ public static class MetadataTypeResolver
     private static IEnumerable<ISymbol> FindMembersInNamespace(
         INamespaceSymbol ns,
         string memberName,
-        string? qualifier)
+        string? qualifier,
+        string? dottedQualifier)
     {
         foreach (INamedTypeSymbol type in ns.GetTypeMembers())
         {
-            foreach (ISymbol member in FindMembersInType(type, memberName, qualifier))
+            foreach (ISymbol member in FindMembersInType(type, memberName, qualifier, dottedQualifier))
             {
                 yield return member;
             }
 
             foreach (INamedTypeSymbol nested in GetNestedTypesRecursive(type))
             {
-                foreach (ISymbol member in FindMembersInType(nested, memberName, qualifier))
+                foreach (ISymbol member in FindMembersInType(nested, memberName, qualifier, dottedQualifier))
                 {
                     yield return member;
                 }
@@ -65,7 +69,7 @@ public static class MetadataTypeResolver
 
         foreach (INamespaceSymbol childNs in ns.GetNamespaceMembers())
         {
-            foreach (ISymbol member in FindMembersInNamespace(childNs, memberName, qualifier))
+            foreach (ISymbol member in FindMembersInNamespace(childNs, memberName, qualifier, dottedQualifier))
             {
                 yield return member;
             }
@@ -75,9 +79,10 @@ public static class MetadataTypeResolver
     private static IEnumerable<ISymbol> FindMembersInType(
         INamedTypeSymbol type,
         string memberName,
-        string? qualifier)
+        string? qualifier,
+        string? dottedQualifier)
     {
-        if (qualifier is not null && !TypeMatchesQualifier(type, qualifier))
+        if (qualifier is not null && !TypeMatchesQualifier(type, qualifier, dottedQualifier!))
         {
             yield break;
         }
@@ -88,11 +93,11 @@ public static class MetadataTypeResolver
         }
     }
 
-    private static bool TypeMatchesQualifier(INamedTypeSymbol type, string qualifier)
+    private static bool TypeMatchesQualifier(INamedTypeSymbol type, string qualifier, string dottedQualifier)
     {
         string displayFqn = type.ToDisplayString();
         if (displayFqn == qualifier
-            || displayFqn.EndsWith($".{qualifier}", StringComparison.Ordinal))
+            || displayFqn.EndsWith(dottedQualifier, StringComparison.Ordinal))
         {
             return true;
         }
@@ -103,7 +108,7 @@ public static class MetadataTypeResolver
             ? type.MetadataName
             : $"{ns}.{type.MetadataName}";
         return metadataFqn == qualifier
-            || metadataFqn.EndsWith($".{qualifier}", StringComparison.Ordinal);
+            || metadataFqn.EndsWith(dottedQualifier, StringComparison.Ordinal);
     }
 
     private static IEnumerable<INamedTypeSymbol> GetNestedTypesRecursive(INamedTypeSymbol type)

--- a/src/MetadataTypeResolver.cs
+++ b/src/MetadataTypeResolver.cs
@@ -4,12 +4,130 @@ namespace RoslynQuery;
 
 public static class MetadataTypeResolver
 {
+    public static IReadOnlyList<ISymbol> FindMetadataMembers(
+        IEnumerable<Compilation> compilations,
+        string memberName,
+        string? qualifier)
+    {
+        ArgumentNullException.ThrowIfNull(compilations);
+        ArgumentNullException.ThrowIfNull(memberName);
+
+        HashSet<string> seen = new();
+        List<ISymbol> results = [];
+
+        foreach (Compilation compilation in compilations)
+        {
+            foreach (MetadataReference reference in compilation.References)
+            {
+                ISymbol? assemblySymbol = compilation.GetAssemblyOrModuleSymbol(reference);
+                if (assemblySymbol is not IAssemblySymbol assembly)
+                {
+                    continue;
+                }
+
+                foreach (ISymbol member in FindMembersInNamespace(
+                    assembly.GlobalNamespace,
+                    memberName,
+                    qualifier))
+                {
+                    string key = member.ToDisplayString();
+                    if (seen.Add(key))
+                    {
+                        results.Add(member);
+                    }
+                }
+            }
+        }
+
+        return results;
+    }
+
+    private static IEnumerable<ISymbol> FindMembersInNamespace(
+        INamespaceSymbol ns,
+        string memberName,
+        string? qualifier)
+    {
+        foreach (INamedTypeSymbol type in ns.GetTypeMembers())
+        {
+            foreach (ISymbol member in FindMembersInType(type, memberName, qualifier))
+            {
+                yield return member;
+            }
+
+            foreach (INamedTypeSymbol nested in GetNestedTypesRecursive(type))
+            {
+                foreach (ISymbol member in FindMembersInType(nested, memberName, qualifier))
+                {
+                    yield return member;
+                }
+            }
+        }
+
+        foreach (INamespaceSymbol childNs in ns.GetNamespaceMembers())
+        {
+            foreach (ISymbol member in FindMembersInNamespace(childNs, memberName, qualifier))
+            {
+                yield return member;
+            }
+        }
+    }
+
+    private static IEnumerable<ISymbol> FindMembersInType(
+        INamedTypeSymbol type,
+        string memberName,
+        string? qualifier)
+    {
+        if (qualifier is not null && !TypeMatchesQualifier(type, qualifier))
+        {
+            yield break;
+        }
+
+        foreach (ISymbol member in type.GetMembers(memberName))
+        {
+            yield return member;
+        }
+    }
+
+    private static bool TypeMatchesQualifier(INamedTypeSymbol type, string qualifier)
+    {
+        string displayFqn = type.ToDisplayString();
+        if (displayFqn == qualifier
+            || displayFqn.EndsWith($".{qualifier}", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // Also check the metadata-qualified name (e.g. "System.String" for the 'string' keyword alias)
+        string ns = type.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+        string metadataFqn = string.IsNullOrEmpty(ns)
+            ? type.MetadataName
+            : $"{ns}.{type.MetadataName}";
+        return metadataFqn == qualifier
+            || metadataFqn.EndsWith($".{qualifier}", StringComparison.Ordinal);
+    }
+
+    private static IEnumerable<INamedTypeSymbol> GetNestedTypesRecursive(INamedTypeSymbol type)
+    {
+        foreach (INamedTypeSymbol nested in type.GetTypeMembers())
+        {
+            yield return nested;
+            foreach (INamedTypeSymbol n in GetNestedTypesRecursive(nested))
+            {
+                yield return n;
+            }
+        }
+    }
+
     public static IReadOnlyList<INamedTypeSymbol> FindMetadataTypes(
         IEnumerable<Compilation> compilations,
         string typeName)
     {
         ArgumentNullException.ThrowIfNull(compilations);
         ArgumentNullException.ThrowIfNull(typeName);
+
+        int lastDot = typeName.LastIndexOf('.');
+        string simpleName = lastDot >= 0 ? typeName[(lastDot + 1)..] : typeName;
+        string? namespaceQualifier = lastDot >= 0 ? typeName[..lastDot] : null;
 
         HashSet<string> seen = new();
         List<INamedTypeSymbol> results = [];
@@ -26,8 +144,14 @@ public static class MetadataTypeResolver
 
                 foreach (INamedTypeSymbol type in FindTypesInNamespace(
                     assembly.GlobalNamespace,
-                    typeName))
+                    simpleName))
                 {
+                    if (namespaceQualifier is not null
+                        && !TypeMatchesNamespaceQualifier(type, namespaceQualifier))
+                    {
+                        continue;
+                    }
+
                     string key = type.ToDisplayString();
                     if (seen.Add(key))
                     {
@@ -40,18 +164,28 @@ public static class MetadataTypeResolver
         return results;
     }
 
+    private static bool TypeMatchesNamespaceQualifier(INamedTypeSymbol type, string qualifier)
+    {
+        string ns = type.ContainingNamespace?.ToDisplayString() ?? string.Empty;
+        string containingType = type.ContainingType?.ToDisplayString() ?? string.Empty;
+        string container = string.IsNullOrEmpty(containingType) ? ns : containingType;
+
+        return container == qualifier
+            || container.EndsWith($".{qualifier}", StringComparison.Ordinal);
+    }
+
     private static IEnumerable<INamedTypeSymbol> FindTypesInNamespace(
         INamespaceSymbol ns,
-        string typeName)
+        string simpleName)
     {
-        foreach (INamedTypeSymbol type in ns.GetTypeMembers(typeName))
+        foreach (INamedTypeSymbol type in ns.GetTypeMembers(simpleName))
         {
             yield return type;
         }
 
         foreach (INamespaceSymbol childNs in ns.GetNamespaceMembers())
         {
-            foreach (INamedTypeSymbol type in FindTypesInNamespace(childNs, typeName))
+            foreach (INamedTypeSymbol type in FindTypesInNamespace(childNs, simpleName))
             {
                 yield return type;
             }

--- a/src/MetadataTypeResolver.cs
+++ b/src/MetadataTypeResolver.cs
@@ -58,11 +58,14 @@ public static class MetadataTypeResolver
                 yield return member;
             }
 
-            foreach (INamedTypeSymbol nested in GetNestedTypesRecursive(type))
+            if (qualifier is null || TypeMatchesQualifier(type, qualifier, dottedQualifier!))
             {
-                foreach (ISymbol member in FindMembersInType(nested, memberName, qualifier, dottedQualifier))
+                foreach (INamedTypeSymbol nested in GetNestedTypesRecursive(type))
                 {
-                    yield return member;
+                    foreach (ISymbol member in FindMembersInType(nested, memberName, qualifier, dottedQualifier))
+                    {
+                        yield return member;
+                    }
                 }
             }
         }

--- a/src/MetadataTypeResolver.cs
+++ b/src/MetadataTypeResolver.cs
@@ -58,14 +58,11 @@ public static class MetadataTypeResolver
                 yield return member;
             }
 
-            if (qualifier is null || TypeMatchesQualifier(type, qualifier, dottedQualifier!))
+            foreach (INamedTypeSymbol nested in NamespaceWalker.GetNestedTypes(type))
             {
-                foreach (INamedTypeSymbol nested in NamespaceWalker.GetNestedTypes(type))
+                foreach (ISymbol member in FindMembersInType(nested, memberName, qualifier, dottedQualifier))
                 {
-                    foreach (ISymbol member in FindMembersInType(nested, memberName, qualifier, dottedQualifier))
-                    {
-                        yield return member;
-                    }
+                    yield return member;
                 }
             }
         }

--- a/src/MetadataTypeResolver.cs
+++ b/src/MetadataTypeResolver.cs
@@ -60,7 +60,7 @@ public static class MetadataTypeResolver
 
             if (qualifier is null || TypeMatchesQualifier(type, qualifier, dottedQualifier!))
             {
-                foreach (INamedTypeSymbol nested in GetNestedTypesRecursive(type))
+                foreach (INamedTypeSymbol nested in NamespaceWalker.GetNestedTypes(type))
                 {
                     foreach (ISymbol member in FindMembersInType(nested, memberName, qualifier, dottedQualifier))
                     {
@@ -112,18 +112,6 @@ public static class MetadataTypeResolver
             : $"{ns}.{type.MetadataName}";
         return metadataFqn == qualifier
             || metadataFqn.EndsWith(dottedQualifier, StringComparison.Ordinal);
-    }
-
-    private static IEnumerable<INamedTypeSymbol> GetNestedTypesRecursive(INamedTypeSymbol type)
-    {
-        foreach (INamedTypeSymbol nested in type.GetTypeMembers())
-        {
-            yield return nested;
-            foreach (INamedTypeSymbol n in GetNestedTypesRecursive(nested))
-            {
-                yield return n;
-            }
-        }
     }
 
     public static IReadOnlyList<INamedTypeSymbol> FindMetadataTypes(

--- a/src/NamespaceWalker.cs
+++ b/src/NamespaceWalker.cs
@@ -1,0 +1,37 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynQuery;
+
+internal static class NamespaceWalker
+{
+    internal static IEnumerable<INamedTypeSymbol> GetAllTypes(INamespaceSymbol ns)
+    {
+        foreach (INamedTypeSymbol type in ns.GetTypeMembers())
+        {
+            yield return type;
+            foreach (INamedTypeSymbol nested in GetNestedTypes(type))
+            {
+                yield return nested;
+            }
+        }
+        foreach (INamespaceSymbol childNs in ns.GetNamespaceMembers())
+        {
+            foreach (INamedTypeSymbol type in GetAllTypes(childNs))
+            {
+                yield return type;
+            }
+        }
+    }
+
+    internal static IEnumerable<INamedTypeSymbol> GetNestedTypes(INamedTypeSymbol type)
+    {
+        foreach (INamedTypeSymbol nested in type.GetTypeMembers())
+        {
+            yield return nested;
+            foreach (INamedTypeSymbol n in GetNestedTypes(nested))
+            {
+                yield return n;
+            }
+        }
+    }
+}

--- a/tests/CommandDispatcherTests/FindTypeByName.cs
+++ b/tests/CommandDispatcherTests/FindTypeByName.cs
@@ -7,56 +7,73 @@ using Shouldly;
 
 namespace roslyn_query.Tests.CommandDispatcherTests;
 
-public sealed class FindSymbolsByName
+public sealed class FindTypeByName
 {
     [Fact]
-    public async Task WhenMethodHasQualifiedReturnType_FindsByFqn()
+    public async Task WhenTypeIsInMetadata_FindImplSucceeds()
     {
-        // Arrange
+        // Arrange — IDisposable is a metadata interface; source implements it
         string source = @"
-using System.Collections.Generic;
+using System;
 
-namespace MyApp.Services
+class MyDisposable : IDisposable
 {
-    public class OrderService
-    {
-        public List<int> GetItems() { return new List<int>(); }
-    }
-
-    public class Consumer
-    {
-        public void Use()
-        {
-            var svc = new OrderService();
-            svc.GetItems();
-        }
-    }
+    public void Dispose() { }
 }";
         Solution solution = CreateSolution(source);
         StringWriter stdout = new();
         StringWriter stderr = new();
         CommandContext context = new(stdout, stderr, solution);
 
-        // Act
+        // Act — find-impl on a metadata interface should find source implementations
         int exitCode = await CommandDispatcher.ExecuteAsync(
-            ["find-refs", "MyApp.Services.OrderService.GetItems"],
+            ["find-impl", "System.IDisposable"],
             context);
 
         // Assert
         exitCode.ShouldBe(0);
-        stdout.ToString().ShouldNotBeEmpty();
+        stderr.ToString().ShouldNotContain("Type not found");
+        stdout.ToString().ShouldContain("MyDisposable");
     }
 
     [Fact]
-    public async Task WhenSymbolIsInMetadata_FindRefsSucceeds()
+    public async Task WhenTypeIsInMetadata_FindBaseSucceeds()
     {
-        // Arrange — source calls string.Format but doesn't define it
+        // Arrange — source class inherits from Exception (a metadata type)
         string source = @"
+using System;
+
+class MyException : Exception
+{
+    public MyException(string message) : base(message) { }
+}";
+        Solution solution = CreateSolution(source);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Act — find-base on a metadata type should not report "Type not found"
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["find-base", "System.Exception"],
+            context);
+
+        // Assert
+        exitCode.ShouldBe(0);
+        stderr.ToString().ShouldNotContain("Type not found");
+    }
+
+    [Fact]
+    public async Task WhenTypeIsInMetadata_FindCtorSucceeds()
+    {
+        // Arrange — source uses ArgumentNullException constructor which is in metadata
+        string source = @"
+using System;
+
 class Caller
 {
     public void Use()
     {
-        string.Format(""{0}"", 1);
+        throw new ArgumentNullException(""param"");
     }
 }";
         Solution solution = CreateSolution(source);
@@ -64,35 +81,14 @@ class Caller
         StringWriter stderr = new();
         CommandContext context = new(stdout, stderr, solution);
 
-        // Act — find-refs on a metadata method should not return "Symbol not found"
-        // Use --all because Format has multiple overloads (ambiguous without --all)
+        // Act — find-ctor on a metadata type should not report "Type not found"
         int exitCode = await CommandDispatcher.ExecuteAsync(
-            ["find-refs", "--all", "System.String.Format"],
+            ["find-ctor", "System.ArgumentNullException"],
             context);
 
         // Assert
         exitCode.ShouldBe(0);
-        stderr.ToString().ShouldNotContain("Symbol not found");
-    }
-
-    [Fact]
-    public async Task WhenSymbolIsInMetadataUnqualified_FindRefsReturnsAmbiguousOrResults()
-    {
-        // Arrange — source has no GetHashCode defined; it's in metadata only
-        string source = "class Caller { }";
-        Solution solution = CreateSolution(source);
-        StringWriter stdout = new();
-        StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution);
-
-        // Act — unqualified metadata method; should not report "Symbol not found"
-        int exitCode = await CommandDispatcher.ExecuteAsync(
-            ["find-refs", "--all", "GetHashCode"],
-            context);
-
-        // Assert — with --all, multiple matches are returned (not a "not found" error)
-        exitCode.ShouldBe(0);
-        stderr.ToString().ShouldNotContain("Symbol not found");
+        stderr.ToString().ShouldNotContain("Type not found");
     }
 
     private static Solution CreateSolution(string source)

--- a/tests/MetadataTypeResolverTests/FindMetadataMembers.cs
+++ b/tests/MetadataTypeResolverTests/FindMetadataMembers.cs
@@ -1,0 +1,93 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.MetadataTypeResolverTests;
+
+public sealed class FindMetadataMembers
+{
+    [Fact]
+    public void WhenMemberExistsInMetadata_ReturnsMember()
+    {
+        // Arrange
+        CSharpCompilation compilation = CreateCompilationWithReferences("class Dummy { }");
+
+        // Act — System.String.Format exists in mscorlib/System.Runtime metadata
+        IReadOnlyList<ISymbol> result = MetadataTypeResolver.FindMetadataMembers(
+            [compilation],
+            "Format",
+            qualifier: null);
+
+        // Assert
+        result.ShouldNotBeEmpty();
+        result.ShouldAllBe(s => s.Name == "Format");
+    }
+
+    [Fact]
+    public void WhenMemberNotFound_ReturnsEmpty()
+    {
+        // Arrange
+        CSharpCompilation compilation = CreateCompilationWithReferences("class Dummy { }");
+
+        // Act
+        IReadOnlyList<ISymbol> result = MetadataTypeResolver.FindMetadataMembers(
+            [compilation],
+            "NonExistentMember99999",
+            qualifier: null);
+
+        // Assert
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void WhenQualifierProvided_FiltersToMatchingType()
+    {
+        // Arrange
+        CSharpCompilation compilation = CreateCompilationWithReferences("class Dummy { }");
+
+        // Act — only System.String.Format, not Console.Format or others
+        IReadOnlyList<ISymbol> result = MetadataTypeResolver.FindMetadataMembers(
+            [compilation],
+            "Format",
+            qualifier: "System.String");
+
+        // Assert
+        result.ShouldNotBeEmpty();
+        result.ShouldAllBe(s => s.ContainingType.ToDisplayString() == "string");
+    }
+
+    [Fact]
+    public void WhenDuplicateAcrossCompilations_ReturnsDistinct()
+    {
+        // Arrange — two compilations both referencing the same System.Runtime
+        CSharpCompilation compilation1 = CreateCompilationWithReferences("class A { }");
+        CSharpCompilation compilation2 = CreateCompilationWithReferences("class B { }");
+
+        // Act
+        IReadOnlyList<ISymbol> result = MetadataTypeResolver.FindMetadataMembers(
+            [compilation1, compilation2],
+            "Format",
+            qualifier: "System.String");
+
+        // Assert
+        int singleCompilationCount = MetadataTypeResolver.FindMetadataMembers(
+            [compilation1],
+            "Format",
+            qualifier: "System.String").Count;
+        result.Count.ShouldBe(singleCompilationCount);
+    }
+
+    private static CSharpCompilation CreateCompilationWithReferences(
+        string source,
+        string assemblyName = "TestAssembly")
+    {
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+        return CSharpCompilation.Create(
+            assemblyName,
+            [tree],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location)]);
+    }
+}

--- a/tests/MetadataTypeResolverTests/FindMetadataMembers.cs
+++ b/tests/MetadataTypeResolverTests/FindMetadataMembers.cs
@@ -80,6 +80,23 @@ public sealed class FindMetadataMembers
         result.Count.ShouldBe(singleCompilationCount);
     }
 
+    [Fact]
+    public void WhenQualifierNamesNestedType_ReturnsMemberOnNestedType()
+    {
+        // Arrange
+        CSharpCompilation compilation = CreateCompilationWithReferences("class Dummy { }");
+
+        // Act — Dictionary<TKey, TValue>.KeyCollection is a nested type; CopyTo is a member of it
+        IReadOnlyList<ISymbol> result = MetadataTypeResolver.FindMetadataMembers(
+            [compilation],
+            "CopyTo",
+            qualifier: "System.Collections.Generic.Dictionary<TKey, TValue>.KeyCollection");
+
+        // Assert
+        result.ShouldNotBeEmpty();
+        result.ShouldAllBe(s => s.ContainingType.Name == "KeyCollection");
+    }
+
     private static CSharpCompilation CreateCompilationWithReferences(
         string source,
         string assemblyName = "TestAssembly")


### PR DESCRIPTION
## Summary
- Add metadata fallback to `FindSymbolsByName` and `FindTypeByName` so `find-callers`, `find-refs`, `find-overrides`, `find-impl`, `find-ctor`, and `find-base` can resolve symbols defined in NuGet packages
- Extend `MetadataTypeResolver` with `FindMetadataMembers` to search referenced assemblies for members by name
- Extract shared `NamespaceWalker` to deduplicate recursive type-walking logic across `CommandDispatcher`, `AttributeScanner`, and `MetadataTypeResolver`
- Eliminate redundant `LoadCompilationsAsync` calls by adding a `Compilation[]` overload to `FindTypeByName`

Closes #52

## Test plan
- [x] Verify `find-callers`, `find-refs`, `find-overrides` find methods defined in NuGet packages
- [x] Verify `find-impl`, `find-ctor`, `find-base` find types defined in NuGet packages
- [x] Verify qualified metadata symbol names work correctly
- [x] Verify nested metadata type member lookup works
- [x] Verify all 201 existing + new tests pass
- [x] Verify source-based lookups are unchanged (regression)