### PR TITLE
feat: add daemon stop --all to kill all running daemons

### DIFF
--- a/reinstall.sh
+++ b/reinstall.sh
@@ -3,17 +3,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "Stopping daemon..."
-roslyn-query daemon stop 2>/dev/null || true
-
-echo "Killing any remaining roslyn-query processes..."
-powershell -NoProfile -Command "
-    Get-Process roslyn-query -ErrorAction SilentlyContinue | ForEach-Object {
-        \$_.Kill()
-        \$null = \$_.WaitForExit(5000)
-    }
-    exit 0
-" || true
+echo "Stopping all daemons..."
+roslyn-query daemon stop --all 2>/dev/null || true
 
 echo "Uninstalling..."
 dotnet tool uninstall -g roslyn-query 2>/dev/null || true

--- a/src/DaemonProcess.cs
+++ b/src/DaemonProcess.cs
@@ -121,6 +121,52 @@ public static class DaemonProcess
         CleanupPidFile(solutionPath);
     }
 
+    public static void StopAllDaemons()
+    {
+        string tempPath = Path.GetTempPath();
+        IEnumerable<string> pidFiles = Directory.EnumerateFiles(tempPath, "roslyn-query-*.pid");
+
+        foreach (string pidFilePath in pidFiles)
+        {
+            StopAndCleanupPidFile(pidFilePath);
+        }
+    }
+
+    private static void StopAndCleanupPidFile(string pidFilePath)
+    {
+        string content = File.ReadAllText(pidFilePath);
+
+        if (!int.TryParse(content, CultureInfo.InvariantCulture, out int pid))
+        {
+            File.Delete(pidFilePath);
+            return;
+        }
+
+        try
+        {
+            using Process process = Process.GetProcessById(pid);
+            if (!IsDaemonProcess(process))
+                return;
+            process.Kill();
+            process.WaitForExit();
+        }
+        catch (ArgumentException)
+        {
+            // Process already exited — stale PID file
+        }
+        catch (InvalidOperationException)
+        {
+            // Process exited between GetProcessById and Kill
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // Kill() was denied — leave PID file intact so future stop attempts can retry
+            return;
+        }
+
+        File.Delete(pidFilePath);
+    }
+
     private static bool IsDaemonProcess(Process process)
     {
         try

--- a/src/DaemonProcess.cs
+++ b/src/DaemonProcess.cs
@@ -112,39 +112,46 @@ public static class DaemonProcess
 
     private static void StopAndCleanupPidFile(string pidFilePath)
     {
-        string content = File.ReadAllText(pidFilePath);
-
-        if (!int.TryParse(content, CultureInfo.InvariantCulture, out int pid))
-        {
-            File.Delete(pidFilePath);
-            return;
-        }
-
         try
         {
-            using Process process = Process.GetProcessById(pid);
-            if (!IsDaemonProcess(process))
+            string content = File.ReadAllText(pidFilePath);
+
+            if (!int.TryParse(content, CultureInfo.InvariantCulture, out int pid))
             {
+                File.Delete(pidFilePath);
                 return;
             }
-            process.Kill();
-            process.WaitForExit();
-        }
-        catch (ArgumentException)
-        {
-            // Process already exited — stale PID file
-        }
-        catch (InvalidOperationException)
-        {
-            // Process exited between GetProcessById and Kill
-        }
-        catch (System.ComponentModel.Win32Exception)
-        {
-            // Kill() was denied — leave PID file intact so future stop attempts can retry
-            return;
-        }
 
-        File.Delete(pidFilePath);
+            try
+            {
+                using Process process = Process.GetProcessById(pid);
+                if (!IsDaemonProcess(process))
+                {
+                    return;
+                }
+                process.Kill();
+                process.WaitForExit();
+            }
+            catch (ArgumentException)
+            {
+                // Process already exited — stale PID file
+            }
+            catch (InvalidOperationException)
+            {
+                // Process exited between GetProcessById and Kill
+            }
+            catch (System.ComponentModel.Win32Exception)
+            {
+                // Kill() was denied — leave PID file intact so future stop attempts can retry
+                return;
+            }
+
+            File.Delete(pidFilePath);
+        }
+        catch (IOException)
+        {
+            // File disappeared or is locked — skip and continue to next PID file
+        }
     }
 
     private static bool IsDaemonProcess(Process process)

--- a/src/DaemonProcess.cs
+++ b/src/DaemonProcess.cs
@@ -91,40 +91,18 @@ public static class DaemonProcess
 
     public static void StopDaemon(string solutionPath)
     {
-        int? pid = ReadPidFile(solutionPath);
-        if (!pid.HasValue)
-            return;
-
-        try
+        string pidFilePath = PipeProtocol.DerivePidFilePath(solutionPath);
+        if (!File.Exists(pidFilePath))
         {
-            using Process process = Process.GetProcessById(pid.Value);
-            if (!IsDaemonProcess(process))
-                return;
-            process.Kill();
-            process.WaitForExit();
-        }
-        catch (ArgumentException)
-        {
-            // Process already exited before GetProcessById
-        }
-        catch (InvalidOperationException)
-        {
-            // Process exited between GetProcessById and Kill
-        }
-        catch (System.ComponentModel.Win32Exception)
-        {
-            // Kill() was denied (e.g. access denied). Daemon is still running —
-            // leave the PID file intact so future stop attempts can retry.
             return;
         }
-
-        CleanupPidFile(solutionPath);
+        StopAndCleanupPidFile(pidFilePath);
     }
 
     public static void StopAllDaemons()
     {
         string tempPath = Path.GetTempPath();
-        IEnumerable<string> pidFiles = Directory.EnumerateFiles(tempPath, "roslyn-query-*.pid");
+        IEnumerable<string> pidFiles = Directory.EnumerateFiles(tempPath, $"{PipeProtocol.Prefix}*.pid");
 
         foreach (string pidFilePath in pidFiles)
         {
@@ -146,7 +124,9 @@ public static class DaemonProcess
         {
             using Process process = Process.GetProcessById(pid);
             if (!IsDaemonProcess(process))
+            {
                 return;
+            }
             process.Kill();
             process.WaitForExit();
         }

--- a/src/PipeProtocol.cs
+++ b/src/PipeProtocol.cs
@@ -7,7 +7,7 @@ namespace RoslynQuery;
 
 public static class PipeProtocol
 {
-    private const string Prefix = "roslyn-query-";
+    internal const string Prefix = "roslyn-query-";
     internal const int MaxFrameBytes = 64 * 1024 * 1024;
 
     public static string DerivePipeName(string solutionPath)

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -56,6 +56,12 @@ static async Task<int> RunDaemon(string[] args)
 
 static int RunDaemonStop(string[] args)
 {
+    if (args.Length >= 3 && args[2] == "--all")
+    {
+        DaemonProcess.StopAllDaemons();
+        return 0;
+    }
+
     string? solutionPath = args.Length >= 3
         ? Path.GetFullPath(args[2])
         : SolutionDiscovery.Discover(Directory.GetCurrentDirectory(), Console.Error);

--- a/tests/DaemonProcessTests/StopAllDaemons.cs
+++ b/tests/DaemonProcessTests/StopAllDaemons.cs
@@ -1,0 +1,76 @@
+using System.Diagnostics;
+using System.Globalization;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.DaemonProcessTests;
+
+public sealed class StopAllDaemons : IDisposable
+{
+    private readonly List<string> _pidFilePaths = [];
+
+    [Fact]
+    public void WhenStalePidFilesExist_DeletesThem()
+    {
+        // Arrange
+        string pidFilePath = CreatePidFile(int.MaxValue);
+
+        // Act
+        DaemonProcess.StopAllDaemons();
+
+        // Assert
+        File.Exists(pidFilePath).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void WhenPidBelongsToNonDaemonProcess_LeavesPidFileIntact()
+    {
+        // Arrange
+        ProcessStartInfo startInfo = new()
+        {
+            FileName = OperatingSystem.IsWindows() ? "ping" : "sleep",
+            Arguments = OperatingSystem.IsWindows() ? "-n 30 127.0.0.1" : "30",
+            CreateNoWindow = true,
+            UseShellExecute = false,
+        };
+
+        using Process dummy = Process.Start(startInfo)!;
+        string pidFilePath = CreatePidFile(dummy.Id);
+
+        try
+        {
+            // Act
+            DaemonProcess.StopAllDaemons();
+
+            // Assert
+            File.Exists(pidFilePath).ShouldBeTrue();
+        }
+        finally
+        {
+            dummy.Kill();
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (string path in _pidFilePaths)
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+
+    private string CreatePidFile(int pid)
+    {
+        // Create a PID file with the roslyn-query-*.pid naming pattern
+        string fileName = $"roslyn-query-{Guid.NewGuid():N}.pid";
+        string pidFilePath = Path.Combine(Path.GetTempPath(), fileName);
+        File.WriteAllText(pidFilePath, pid.ToString(CultureInfo.InvariantCulture));
+        _pidFilePaths.Add(pidFilePath);
+        return pidFilePath;
+    }
+}

--- a/tests/DaemonProcessTests/StopAllDaemons.cs
+++ b/tests/DaemonProcessTests/StopAllDaemons.cs
@@ -25,6 +25,19 @@ public sealed class StopAllDaemons : IDisposable
     }
 
     [Fact]
+    public void WhenPidFileContainsNonIntegerContent_DeletesFile()
+    {
+        // Arrange
+        string pidFilePath = CreatePidFileWithContent("not-a-number");
+
+        // Act
+        DaemonProcess.StopAllDaemons();
+
+        // Assert
+        File.Exists(pidFilePath).ShouldBeFalse();
+    }
+
+    [Fact]
     public void WhenPidBelongsToNonDaemonProcess_LeavesPidFileIntact()
     {
         // Arrange
@@ -70,6 +83,15 @@ public sealed class StopAllDaemons : IDisposable
         string fileName = $"roslyn-query-{Guid.NewGuid():N}.pid";
         string pidFilePath = Path.Combine(Path.GetTempPath(), fileName);
         File.WriteAllText(pidFilePath, pid.ToString(CultureInfo.InvariantCulture));
+        _pidFilePaths.Add(pidFilePath);
+        return pidFilePath;
+    }
+
+    private string CreatePidFileWithContent(string content)
+    {
+        string fileName = $"roslyn-query-{Guid.NewGuid():N}.pid";
+        string pidFilePath = Path.Combine(Path.GetTempPath(), fileName);
+        File.WriteAllText(pidFilePath, content);
         _pidFilePaths.Add(pidFilePath);
         return pidFilePath;
     }


### PR DESCRIPTION
## Summary

- Adds `roslyn-query daemon stop --all` to enumerate and kill all running daemons, making `dotnet tool uninstall -g roslyn-query` reliable
- Refactors `StopDaemon` to delegate to `StopAndCleanupPidFile`, eliminating duplicated kill/wait/catch logic
- Simplifies `reinstall.sh` by replacing the PowerShell fallback with the new `--all` flag

Closes #54

## Test plan

- [x] `WhenStalePidFilesExist_DeletesThem` — stale PID files are cleaned up
- [x] `WhenPidFileContainsNonIntegerContent_DeletesFile` — corrupt PID files are deleted
- [x] `WhenPidBelongsToNonDaemonProcess_LeavesPidFileIntact` — non-daemon processes are not killed
- [ ] Manual: run `roslyn-query daemon stop --all` with multiple daemons running, then `dotnet tool uninstall -g roslyn-query`