### PR TITLE
fix: track csproj, lock files, and Directory.*.props for daemon reload detection

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.22.0.136894" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="9.0.15" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>

--- a/src/DaemonServer.cs
+++ b/src/DaemonServer.cs
@@ -72,8 +72,7 @@ public static class DaemonServer
                         pipe,
                         linkedCts.Token);
 
-                    DateTime currentWriteTime = TrackedFiles.ComputeMaxWriteTime(reloadState.TrackedPaths);
-                    if (currentWriteTime > reloadState.LastWriteTime)
+                    if (reloadState.IsStale())
                     {
                         await PipeProtocol.WriteResponseAsync(
                             pipe,

--- a/src/DaemonServer.cs
+++ b/src/DaemonServer.cs
@@ -10,6 +10,7 @@ namespace RoslynQuery;
 public static class DaemonServer
 {
     private static readonly TimeSpan IdleTimeout = TimeSpan.FromMinutes(30);
+    private static readonly TimeSpan StalenessCheckInterval = TimeSpan.FromSeconds(2);
     private const int TransientExitCode = 75;
     private const uint OwnerOnlyUmask = 0x7F; // 0177 octal — restricts group/other r/w/x
 
@@ -47,6 +48,7 @@ public static class DaemonServer
             solutionDirectory,
             solutionPath);
         ReloadState reloadState = new(workspace.CurrentSolution, initialTrackedPaths);
+        DateTime lastStalenessCheck = DateTime.MinValue;
 
         ApplyUnixPipeUmask();
 
@@ -72,7 +74,14 @@ public static class DaemonServer
                         pipe,
                         linkedCts.Token);
 
-                    if (reloadState.IsStale())
+                    bool stale = false;
+                    if (DateTime.UtcNow - lastStalenessCheck >= StalenessCheckInterval)
+                    {
+                        lastStalenessCheck = DateTime.UtcNow;
+                        stale = await reloadState.IsStaleAsync();
+                    }
+
+                    if (stale)
                     {
                         await PipeProtocol.WriteResponseAsync(
                             pipe,

--- a/src/DaemonServer.cs
+++ b/src/DaemonServer.cs
@@ -38,11 +38,15 @@ public static class DaemonServer
         AppDomain.CurrentDomain.ProcessExit += (_, _) =>
             DaemonProcess.CleanupPidFile(solutionPath);
 
+        string solutionDirectory = Path.GetDirectoryName(solutionPath) ?? "";
+
         using MSBuildWorkspace workspace = MSBuildWorkspace.Create();
         await SolutionLoader.LoadAsync(workspace, solutionPath, cancellationToken);
-        ReloadState reloadState = new(
+        IReadOnlyList<string> initialTrackedPaths = TrackedFiles.CollectPaths(
             workspace.CurrentSolution,
-            File.GetLastWriteTimeUtc(solutionPath));
+            solutionDirectory,
+            solutionPath);
+        ReloadState reloadState = new(workspace.CurrentSolution, initialTrackedPaths);
 
         ApplyUnixPipeUmask();
 
@@ -68,7 +72,7 @@ public static class DaemonServer
                         pipe,
                         linkedCts.Token);
 
-                    DateTime currentWriteTime = File.GetLastWriteTimeUtc(solutionPath);
+                    DateTime currentWriteTime = TrackedFiles.ComputeMaxWriteTime(reloadState.TrackedPaths);
                     if (currentWriteTime > reloadState.LastWriteTime)
                     {
                         await PipeProtocol.WriteResponseAsync(
@@ -90,9 +94,13 @@ public static class DaemonServer
                                             workspace,
                                             solutionPath,
                                             cancellationToken);
+                                        IReadOnlyList<string> reloadedPaths = TrackedFiles.CollectPaths(
+                                            workspace.CurrentSolution,
+                                            solutionDirectory,
+                                            solutionPath);
                                         reloadState.CompleteReload(
                                             workspace.CurrentSolution,
-                                            File.GetLastWriteTimeUtc(solutionPath));
+                                            reloadedPaths);
                                     }
 #pragma warning disable CA1031 // Abort reload on any failure to avoid stuck state
                                     catch
@@ -109,7 +117,6 @@ public static class DaemonServer
 
                     StringWriter stdoutWriter = new();
                     StringWriter stderrWriter = new();
-                    string solutionDirectory = Path.GetDirectoryName(solutionPath) ?? "";
                     CommandContext context = new(
                         stdoutWriter,
                         stderrWriter,

--- a/src/ReloadState.cs
+++ b/src/ReloadState.cs
@@ -6,13 +6,18 @@ public sealed class ReloadState
 {
     private readonly Lock _lock = new();
     private Solution _solution;
+    private IReadOnlyList<string> _trackedPaths;
     private DateTime _lastWriteTime;
     private bool _reloading;
 
-    public ReloadState(Solution solution, DateTime lastWriteTime)
+    public ReloadState(Solution solution, IReadOnlyList<string> trackedPaths)
     {
+        ArgumentNullException.ThrowIfNull(solution);
+        ArgumentNullException.ThrowIfNull(trackedPaths);
+
         _solution = solution;
-        _lastWriteTime = lastWriteTime;
+        _trackedPaths = trackedPaths;
+        _lastWriteTime = TrackedFiles.ComputeMaxWriteTime(trackedPaths);
     }
 
     public Solution Solution
@@ -22,6 +27,17 @@ public sealed class ReloadState
             lock (_lock)
             {
                 return _solution;
+            }
+        }
+    }
+
+    public IReadOnlyList<string> TrackedPaths
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _trackedPaths;
             }
         }
     }
@@ -51,12 +67,16 @@ public sealed class ReloadState
         }
     }
 
-    public void CompleteReload(Solution solution, DateTime lastWriteTime)
+    public void CompleteReload(Solution solution, IReadOnlyList<string> trackedPaths)
     {
+        ArgumentNullException.ThrowIfNull(solution);
+        ArgumentNullException.ThrowIfNull(trackedPaths);
+
         lock (_lock)
         {
             _solution = solution;
-            _lastWriteTime = lastWriteTime;
+            _trackedPaths = trackedPaths;
+            _lastWriteTime = TrackedFiles.ComputeMaxWriteTime(trackedPaths);
             _reloading = false;
         }
     }

--- a/src/ReloadState.cs
+++ b/src/ReloadState.cs
@@ -53,6 +53,15 @@ public sealed class ReloadState
         }
     }
 
+    public bool IsStale()
+    {
+        lock (_lock)
+        {
+            DateTime currentWriteTime = TrackedFiles.ComputeMaxWriteTime(_trackedPaths);
+            return currentWriteTime > _lastWriteTime;
+        }
+    }
+
     public bool TryBeginReload()
     {
         lock (_lock)

--- a/src/ReloadState.cs
+++ b/src/ReloadState.cs
@@ -53,7 +53,7 @@ public sealed class ReloadState
         }
     }
 
-    public bool IsStale()
+    public async Task<bool> IsStaleAsync()
     {
         IReadOnlyList<string> paths;
         DateTime lastWriteTime;
@@ -64,7 +64,8 @@ public sealed class ReloadState
             lastWriteTime = _lastWriteTime;
         }
 
-        return TrackedFiles.ComputeMaxWriteTime(paths) > lastWriteTime;
+        DateTime maxWriteTime = await Task.Run(() => TrackedFiles.ComputeMaxWriteTime(paths));
+        return maxWriteTime > lastWriteTime;
     }
 
     public bool TryBeginReload()

--- a/src/ReloadState.cs
+++ b/src/ReloadState.cs
@@ -72,11 +72,13 @@ public sealed class ReloadState
         ArgumentNullException.ThrowIfNull(solution);
         ArgumentNullException.ThrowIfNull(trackedPaths);
 
+        DateTime lastWriteTime = TrackedFiles.ComputeMaxWriteTime(trackedPaths);
+
         lock (_lock)
         {
             _solution = solution;
             _trackedPaths = trackedPaths;
-            _lastWriteTime = TrackedFiles.ComputeMaxWriteTime(trackedPaths);
+            _lastWriteTime = lastWriteTime;
             _reloading = false;
         }
     }

--- a/src/ReloadState.cs
+++ b/src/ReloadState.cs
@@ -55,11 +55,16 @@ public sealed class ReloadState
 
     public bool IsStale()
     {
+        IReadOnlyList<string> paths;
+        DateTime lastWriteTime;
+
         lock (_lock)
         {
-            DateTime currentWriteTime = TrackedFiles.ComputeMaxWriteTime(_trackedPaths);
-            return currentWriteTime > _lastWriteTime;
+            paths = _trackedPaths;
+            lastWriteTime = _lastWriteTime;
         }
+
+        return TrackedFiles.ComputeMaxWriteTime(paths) > lastWriteTime;
     }
 
     public bool TryBeginReload()

--- a/src/TrackedFiles.cs
+++ b/src/TrackedFiles.cs
@@ -20,10 +20,24 @@ public static class TrackedFiles
 
         List<string> paths = [solutionFilePath];
 
-        paths.AddRange(solution.Projects
+        IEnumerable<string> projectFilePaths = solution.Projects
             .Where(p => p.FilePath is not null)
             .Where(p => File.Exists(p.FilePath))
-            .Select(p => p.FilePath!));
+            .Select(p => p.FilePath!);
+
+        foreach (string projectFilePath in projectFilePaths)
+        {
+            paths.Add(projectFilePath);
+
+            string lockFilePath = Path.Combine(
+                Path.GetDirectoryName(projectFilePath)!,
+                "packages.lock.json");
+
+            if (File.Exists(lockFilePath))
+            {
+                paths.Add(lockFilePath);
+            }
+        }
 
         paths.AddRange(DiscoverPropsFiles(solutionDirectory));
 
@@ -53,11 +67,14 @@ public static class TrackedFiles
         return max;
     }
 
+    private const int MaxAncestorDepth = 20;
+
     private static IEnumerable<string> DiscoverPropsFiles(string startDirectory)
     {
         string? current = startDirectory;
+        int depth = 0;
 
-        while (current is not null)
+        while (current is not null && depth <= MaxAncestorDepth)
         {
             foreach (string fileName in PropsFileNames)
             {
@@ -68,8 +85,15 @@ public static class TrackedFiles
                 }
             }
 
+            bool isGitRoot = Directory.Exists(Path.Combine(current, ".git"));
+            if (isGitRoot)
+            {
+                yield break;
+            }
+
             string? parent = Path.GetDirectoryName(current);
             current = parent != current ? parent : null;
+            depth++;
         }
     }
 }

--- a/src/TrackedFiles.cs
+++ b/src/TrackedFiles.cs
@@ -26,6 +26,8 @@ public static class TrackedFiles
         return paths;
     }
 
+    private static readonly DateTime MissingFileSentinel = DateTime.FromFileTimeUtc(0);
+
     public static DateTime ComputeMaxWriteTime(IReadOnlyList<string> paths)
     {
         ArgumentNullException.ThrowIfNull(paths);
@@ -34,9 +36,11 @@ public static class TrackedFiles
 
         foreach (string path in paths)
         {
-            DateTime writeTime = File.Exists(path)
-                ? File.GetLastWriteTimeUtc(path)
-                : DateTime.MaxValue;
+            DateTime writeTime = File.GetLastWriteTimeUtc(path);
+            if (writeTime == MissingFileSentinel)
+            {
+                writeTime = DateTime.MaxValue;
+            }
 
             if (writeTime > max)
             {

--- a/src/TrackedFiles.cs
+++ b/src/TrackedFiles.cs
@@ -7,6 +7,8 @@ public static class TrackedFiles
     private static readonly string[] PropsFileNames =
         ["Directory.Packages.props", "Directory.Build.props"];
 
+    private static readonly DateTime MissingFileSentinel = DateTime.FromFileTimeUtc(0);
+
     public static IReadOnlyList<string> CollectPaths(
         Solution solution,
         string solutionDirectory,
@@ -27,8 +29,6 @@ public static class TrackedFiles
 
         return paths;
     }
-
-    private static readonly DateTime MissingFileSentinel = DateTime.FromFileTimeUtc(0);
 
     public static DateTime ComputeMaxWriteTime(IReadOnlyList<string> paths)
     {

--- a/src/TrackedFiles.cs
+++ b/src/TrackedFiles.cs
@@ -1,0 +1,68 @@
+using Microsoft.CodeAnalysis;
+
+namespace RoslynQuery;
+
+public static class TrackedFiles
+{
+    private static readonly string[] PropsFileNames =
+        ["Directory.Packages.props", "Directory.Build.props"];
+
+    public static IReadOnlyList<string> CollectPaths(
+        Solution solution,
+        string solutionDirectory,
+        string solutionFilePath)
+    {
+        ArgumentNullException.ThrowIfNull(solution);
+
+        List<string> paths = [solutionFilePath];
+
+        paths.AddRange(solution.Projects
+            .Where(p => p.FilePath is not null)
+            .Select(p => p.FilePath!));
+
+        paths.AddRange(DiscoverPropsFiles(solutionDirectory));
+
+        return paths;
+    }
+
+    public static DateTime ComputeMaxWriteTime(IReadOnlyList<string> paths)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+
+        DateTime max = DateTime.MinValue;
+
+        foreach (string path in paths)
+        {
+            DateTime writeTime = File.Exists(path)
+                ? File.GetLastWriteTimeUtc(path)
+                : DateTime.MaxValue;
+
+            if (writeTime > max)
+            {
+                max = writeTime;
+            }
+        }
+
+        return max;
+    }
+
+    private static IEnumerable<string> DiscoverPropsFiles(string startDirectory)
+    {
+        string? current = startDirectory;
+
+        while (current is not null)
+        {
+            foreach (string fileName in PropsFileNames)
+            {
+                string candidate = Path.Combine(current, fileName);
+                if (File.Exists(candidate))
+                {
+                    yield return candidate;
+                }
+            }
+
+            string? parent = Path.GetDirectoryName(current);
+            current = parent != current ? parent : null;
+        }
+    }
+}

--- a/src/TrackedFiles.cs
+++ b/src/TrackedFiles.cs
@@ -13,6 +13,8 @@ public static class TrackedFiles
         string solutionFilePath)
     {
         ArgumentNullException.ThrowIfNull(solution);
+        ArgumentException.ThrowIfNullOrEmpty(solutionFilePath);
+        ArgumentException.ThrowIfNullOrEmpty(solutionDirectory);
 
         List<string> paths = [solutionFilePath];
 

--- a/src/TrackedFiles.cs
+++ b/src/TrackedFiles.cs
@@ -18,6 +18,7 @@ public static class TrackedFiles
 
         paths.AddRange(solution.Projects
             .Where(p => p.FilePath is not null)
+            .Where(p => File.Exists(p.FilePath))
             .Select(p => p.FilePath!));
 
         paths.AddRange(DiscoverPropsFiles(solutionDirectory));

--- a/src/roslyn-query.csproj
+++ b/src/roslyn-query.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="Microsoft.Build.Tasks.Core" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
+    <!-- Direct reference to override vulnerable transitive dependency -->
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>

--- a/tests/DaemonIntegrationTests/ReloadDuringCommand.cs
+++ b/tests/DaemonIntegrationTests/ReloadDuringCommand.cs
@@ -21,9 +21,7 @@ public sealed class ReloadDuringCommand
 
         AdhocWorkspace workspace = new();
         Solution solution = workspace.CurrentSolution;
-        ReloadState reloadState = new(
-            solution,
-            new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        ReloadState reloadState = new(solution, []);
 
         reloadState.TryBeginReload().ShouldBeTrue();
 
@@ -66,9 +64,7 @@ public sealed class ReloadDuringCommand
         exitCode.ShouldBe(TransientExitCode);
         stderr.ToString().ShouldBe("daemon: workspace reloading");
 
-        reloadState.CompleteReload(
-            solution,
-            new DateTime(2025, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+        reloadState.CompleteReload(solution, []);
 
         reloadState.Solution.ShouldNotBeNull();
     }

--- a/tests/ReloadStateTests/CompleteReload.cs
+++ b/tests/ReloadStateTests/CompleteReload.cs
@@ -14,8 +14,7 @@ public sealed class CompleteReload
         // Arrange
         AdhocWorkspace workspace = new();
         Solution initialSolution = workspace.CurrentSolution;
-        DateTime initialTime = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        ReloadState sut = new(initialSolution, initialTime);
+        ReloadState sut = new(initialSolution, []);
 
         const int iterations = 1000;
         NullReferenceException? readerException = null;
@@ -25,9 +24,7 @@ public sealed class CompleteReload
         {
             for (int i = 0; i < iterations; i++)
             {
-                sut.CompleteReload(
-                    initialSolution,
-                    initialTime.AddMinutes(i));
+                sut.CompleteReload(initialSolution, []);
             }
         });
 

--- a/tests/ReloadStateTests/IsStale.cs
+++ b/tests/ReloadStateTests/IsStale.cs
@@ -1,0 +1,78 @@
+using Microsoft.CodeAnalysis;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.ReloadStateTests;
+
+public sealed class IsStale
+{
+    [Fact]
+    public void WhenTrackedFileIsNewerThanLastWriteTime_ReturnsTrue()
+    {
+        // Arrange
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        try
+        {
+            string csprojPath = Path.Combine(dir, "Alpha.csproj");
+            File.WriteAllText(csprojPath, "<Project />");
+
+            DateTime oldTime = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            File.SetLastWriteTimeUtc(csprojPath, oldTime);
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.CurrentSolution;
+
+            ReloadState sut = new(solution, [csprojPath]);
+
+            // Update the file after construction so it appears newer
+            DateTime newTime = new(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+            File.SetLastWriteTimeUtc(csprojPath, newTime);
+
+            // Act
+            bool result = sut.IsStale();
+
+            // Assert
+            result.ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenTrackedFilesAreUnchanged_ReturnsFalse()
+    {
+        // Arrange
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        try
+        {
+            string csprojPath = Path.Combine(dir, "Alpha.csproj");
+            File.WriteAllText(csprojPath, "<Project />");
+
+            DateTime fixedTime = new(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc);
+            File.SetLastWriteTimeUtc(csprojPath, fixedTime);
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.CurrentSolution;
+
+            ReloadState sut = new(solution, [csprojPath]);
+
+            // Act
+            bool result = sut.IsStale();
+
+            // Assert
+            result.ShouldBeFalse();
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/tests/ReloadStateTests/IsStale.cs
+++ b/tests/ReloadStateTests/IsStale.cs
@@ -9,7 +9,7 @@ namespace roslyn_query.Tests.ReloadStateTests;
 public sealed class IsStale
 {
     [Fact]
-    public void WhenTrackedFileIsNewerThanLastWriteTime_ReturnsTrue()
+    public async Task WhenTrackedFileIsNewerThanLastWriteTime_ReturnsTrue()
     {
         // Arrange
         string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -18,7 +18,7 @@ public sealed class IsStale
         try
         {
             string csprojPath = Path.Combine(dir, "Alpha.csproj");
-            File.WriteAllText(csprojPath, "<Project />");
+            await File.WriteAllTextAsync(csprojPath, "<Project />");
 
             DateTime oldTime = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
             File.SetLastWriteTimeUtc(csprojPath, oldTime);
@@ -33,7 +33,7 @@ public sealed class IsStale
             File.SetLastWriteTimeUtc(csprojPath, newTime);
 
             // Act
-            bool result = sut.IsStale();
+            bool result = await sut.IsStaleAsync();
 
             // Assert
             result.ShouldBeTrue();
@@ -45,7 +45,7 @@ public sealed class IsStale
     }
 
     [Fact]
-    public void WhenTrackedFilesAreUnchanged_ReturnsFalse()
+    public async Task WhenTrackedFilesAreUnchanged_ReturnsFalse()
     {
         // Arrange
         string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -54,7 +54,7 @@ public sealed class IsStale
         try
         {
             string csprojPath = Path.Combine(dir, "Alpha.csproj");
-            File.WriteAllText(csprojPath, "<Project />");
+            await File.WriteAllTextAsync(csprojPath, "<Project />");
 
             DateTime fixedTime = new(2025, 3, 1, 0, 0, 0, DateTimeKind.Utc);
             File.SetLastWriteTimeUtc(csprojPath, fixedTime);
@@ -65,7 +65,7 @@ public sealed class IsStale
             ReloadState sut = new(solution, [csprojPath]);
 
             // Act
-            bool result = sut.IsStale();
+            bool result = await sut.IsStaleAsync();
 
             // Assert
             result.ShouldBeFalse();

--- a/tests/ReloadStateTests/LastWriteTime.cs
+++ b/tests/ReloadStateTests/LastWriteTime.cs
@@ -1,0 +1,63 @@
+using Microsoft.CodeAnalysis;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.ReloadStateTests;
+
+public sealed class LastWriteTime
+{
+    [Fact]
+    public void ReflectsMaxWriteTimeOfTrackedPaths()
+    {
+        // Arrange
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        try
+        {
+            string fileA = Path.Combine(dir, "A.csproj");
+            string fileB = Path.Combine(dir, "B.csproj");
+            File.WriteAllText(fileA, "");
+            File.WriteAllText(fileB, "");
+
+            DateTime earlierTime = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            DateTime laterTime = new(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+            File.SetLastWriteTimeUtc(fileA, earlierTime);
+            File.SetLastWriteTimeUtc(fileB, laterTime);
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.CurrentSolution;
+
+            // Act
+            ReloadState sut = new(solution, [fileA, fileB]);
+
+            // Assert
+            sut.LastWriteTime.ShouldBe(laterTime);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenTrackedFileDeleted_LastWriteTimeIsMaxValue()
+    {
+        // Arrange
+        string missingPath = Path.Combine(
+            Path.GetTempPath(),
+            Guid.NewGuid().ToString("N"),
+            "Missing.csproj");
+
+        using AdhocWorkspace workspace = new();
+        Solution solution = workspace.CurrentSolution;
+
+        // Act
+        ReloadState sut = new(solution, [missingPath]);
+
+        // Assert
+        sut.LastWriteTime.ShouldBe(DateTime.MaxValue);
+    }
+}

--- a/tests/ReloadStateTests/TrackedPaths.cs
+++ b/tests/ReloadStateTests/TrackedPaths.cs
@@ -1,0 +1,72 @@
+using Microsoft.CodeAnalysis;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.ReloadStateTests;
+
+public sealed class TrackedPaths
+{
+    [Fact]
+    public void WhenConstructed_ExposesTrackedPaths()
+    {
+        // Arrange
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        try
+        {
+            string csprojPath = Path.Combine(dir, "Alpha.csproj");
+            File.WriteAllText(csprojPath, "<Project />");
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.CurrentSolution;
+            IReadOnlyList<string> trackedPaths = [csprojPath];
+
+            // Act
+            ReloadState sut = new(solution, trackedPaths);
+
+            // Assert
+            sut.TrackedPaths.ShouldBe(trackedPaths);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenCompleteReloadCalled_UpdatesTrackedPaths()
+    {
+        // Arrange
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        try
+        {
+            string initialPath = Path.Combine(dir, "Alpha.csproj");
+            string updatedPath = Path.Combine(dir, "Beta.csproj");
+            File.WriteAllText(initialPath, "<Project />");
+            File.WriteAllText(updatedPath, "<Project />");
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.CurrentSolution;
+
+            ReloadState sut = new(solution, [initialPath]);
+
+            IReadOnlyList<string> updatedPaths = [updatedPath];
+
+            // Act
+            sut.TryBeginReload();
+            sut.CompleteReload(solution, updatedPaths);
+
+            // Assert
+            sut.TrackedPaths.ShouldBe(updatedPaths);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/tests/ReloadStateTests/TrackedPaths.cs
+++ b/tests/ReloadStateTests/TrackedPaths.cs
@@ -12,28 +12,15 @@ public sealed class TrackedPaths
     public void WhenConstructed_ExposesTrackedPaths()
     {
         // Arrange
-        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(dir);
+        using AdhocWorkspace workspace = new();
+        Solution solution = workspace.CurrentSolution;
+        IReadOnlyList<string> trackedPaths = [@"C:\projects\Alpha\Alpha.csproj"];
 
-        try
-        {
-            string csprojPath = Path.Combine(dir, "Alpha.csproj");
-            File.WriteAllText(csprojPath, "<Project />");
+        // Act
+        ReloadState sut = new(solution, trackedPaths);
 
-            using AdhocWorkspace workspace = new();
-            Solution solution = workspace.CurrentSolution;
-            IReadOnlyList<string> trackedPaths = [csprojPath];
-
-            // Act
-            ReloadState sut = new(solution, trackedPaths);
-
-            // Assert
-            sut.TrackedPaths.ShouldBe(trackedPaths);
-        }
-        finally
-        {
-            Directory.Delete(dir, recursive: true);
-        }
+        // Assert
+        sut.TrackedPaths.ShouldBe(trackedPaths);
     }
 
     [Fact]
@@ -58,7 +45,7 @@ public sealed class TrackedPaths
             IReadOnlyList<string> updatedPaths = [updatedPath];
 
             // Act
-            sut.TryBeginReload();
+            sut.TryBeginReload().ShouldBeTrue();
             sut.CompleteReload(solution, updatedPaths);
 
             // Assert

--- a/tests/ReloadStateTests/TryBeginReload.cs
+++ b/tests/ReloadStateTests/TryBeginReload.cs
@@ -14,8 +14,7 @@ public sealed class TryBeginReload
         // Arrange
         AdhocWorkspace workspace = new();
         Solution initialSolution = workspace.CurrentSolution;
-        DateTime initialTime = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        ReloadState sut = new(initialSolution, initialTime);
+        ReloadState sut = new(initialSolution, []);
 
         using ManualResetEventSlim barrier = new(false);
         bool result1 = false;

--- a/tests/TrackedFilesTests/CollectPaths.cs
+++ b/tests/TrackedFilesTests/CollectPaths.cs
@@ -118,7 +118,7 @@ public sealed class CollectPaths
             // Act
             IReadOnlyList<string> paths = TrackedFiles.CollectPaths(solution, solutionDir, solutionPath);
 
-            // Assert — only the solution file itself, no csproj
+            // Assert
             paths.ShouldBe([solutionPath]);
         }
         finally

--- a/tests/TrackedFilesTests/CollectPaths.cs
+++ b/tests/TrackedFilesTests/CollectPaths.cs
@@ -220,4 +220,151 @@ public sealed class CollectPaths
             Directory.Delete(solutionDir, recursive: true);
         }
     }
+
+    [Fact]
+    public void WhenProjectHasPackagesLockJson_IncludesIt()
+    {
+        // Arrange
+        string solutionDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(solutionDir);
+
+        try
+        {
+            string solutionPath = Path.Combine(solutionDir, "Solution.sln");
+            string projectDir = Path.Combine(solutionDir, "Alpha");
+            Directory.CreateDirectory(projectDir);
+            string csprojPath = Path.Combine(projectDir, "Alpha.csproj");
+            string lockFilePath = Path.Combine(projectDir, "packages.lock.json");
+            File.WriteAllText(csprojPath, "<Project />");
+            File.WriteAllText(lockFilePath, "{}");
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.AddProject(ProjectInfo.Create(
+                ProjectId.CreateNewId(),
+                VersionStamp.Create(),
+                "Alpha",
+                "Alpha",
+                LanguageNames.CSharp,
+                filePath: csprojPath))
+                .Solution;
+
+            // Act
+            IReadOnlyList<string> paths = TrackedFiles.CollectPaths(solution, solutionDir, solutionPath);
+
+            // Assert
+            paths.ShouldContain(lockFilePath);
+        }
+        finally
+        {
+            Directory.Delete(solutionDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenPropsFileIsAboveGitRoot_DoesNotIncludeIt()
+    {
+        // Arrange
+        // Structure: rootDir/above.props, rootDir/repo/.git, rootDir/repo/src/Solution.sln
+        // The walk stops at rootDir/repo (the git root) and must not reach rootDir/above.props
+        string rootDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        string repoDir = Path.Combine(rootDir, "repo");
+        string gitDir = Path.Combine(repoDir, ".git");
+        string solutionDir = Path.Combine(repoDir, "src");
+        Directory.CreateDirectory(gitDir);
+        Directory.CreateDirectory(solutionDir);
+
+        try
+        {
+            string aboveGitRootPropsPath = Path.Combine(rootDir, "Directory.Packages.props");
+            File.WriteAllText(aboveGitRootPropsPath, "<Project />");
+
+            string solutionPath = Path.Combine(solutionDir, "Solution.sln");
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.CurrentSolution;
+
+            // Act
+            IReadOnlyList<string> paths = TrackedFiles.CollectPaths(solution, solutionDir, solutionPath);
+
+            // Assert — the props file above the git root must not be tracked
+            paths.ShouldNotContain(aboveGitRootPropsPath);
+        }
+        finally
+        {
+            Directory.Delete(rootDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenPropsFileIsAtGitRoot_IncludesIt()
+    {
+        // Arrange
+        // Structure: rootDir/.git, rootDir/Directory.Packages.props, rootDir/src/Solution.sln
+        // The walk should find the props file at the git root level and include it
+        string rootDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        string gitDir = Path.Combine(rootDir, ".git");
+        string solutionDir = Path.Combine(rootDir, "src");
+        Directory.CreateDirectory(gitDir);
+        Directory.CreateDirectory(solutionDir);
+
+        try
+        {
+            string propsAtGitRoot = Path.Combine(rootDir, "Directory.Packages.props");
+            File.WriteAllText(propsAtGitRoot, "<Project />");
+
+            string solutionPath = Path.Combine(solutionDir, "Solution.sln");
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.CurrentSolution;
+
+            // Act
+            IReadOnlyList<string> paths = TrackedFiles.CollectPaths(solution, solutionDir, solutionPath);
+
+            // Assert — the props file at the git root must be tracked
+            paths.ShouldContain(propsAtGitRoot);
+        }
+        finally
+        {
+            Directory.Delete(rootDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenProjectHasNoPackagesLockJson_DoesNotIncludeIt()
+    {
+        // Arrange
+        string solutionDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(solutionDir);
+
+        try
+        {
+            string solutionPath = Path.Combine(solutionDir, "Solution.sln");
+            string projectDir = Path.Combine(solutionDir, "Alpha");
+            Directory.CreateDirectory(projectDir);
+            string csprojPath = Path.Combine(projectDir, "Alpha.csproj");
+            File.WriteAllText(csprojPath, "<Project />");
+            // No packages.lock.json created
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.AddProject(ProjectInfo.Create(
+                ProjectId.CreateNewId(),
+                VersionStamp.Create(),
+                "Alpha",
+                "Alpha",
+                LanguageNames.CSharp,
+                filePath: csprojPath))
+                .Solution;
+
+            // Act
+            IReadOnlyList<string> paths = TrackedFiles.CollectPaths(solution, solutionDir, solutionPath);
+
+            // Assert
+            string expectedLockPath = Path.Combine(projectDir, "packages.lock.json");
+            paths.ShouldNotContain(expectedLockPath);
+        }
+        finally
+        {
+            Directory.Delete(solutionDir, recursive: true);
+        }
+    }
 }

--- a/tests/TrackedFilesTests/CollectPaths.cs
+++ b/tests/TrackedFilesTests/CollectPaths.cs
@@ -164,4 +164,41 @@ public sealed class CollectPaths
             Directory.Delete(solutionDir, recursive: true);
         }
     }
+
+    [Fact]
+    public void WhenProjectFileDoesNotExistOnDisk_ExcludesCsprojPath()
+    {
+        // Arrange
+        string solutionDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(solutionDir);
+
+        try
+        {
+            string solutionPath = Path.Combine(solutionDir, "Solution.sln");
+            File.WriteAllText(solutionPath, "");
+
+            string deletedCsprojPath = Path.Combine(solutionDir, "Deleted", "Deleted.csproj");
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.AddProject(ProjectInfo.Create(
+                ProjectId.CreateNewId(),
+                VersionStamp.Create(),
+                "Deleted",
+                "Deleted",
+                LanguageNames.CSharp,
+                filePath: deletedCsprojPath))
+                .Solution;
+
+            // Act
+            IReadOnlyList<string> paths = TrackedFiles.CollectPaths(solution, solutionDir, solutionPath);
+
+            // Assert
+            paths.ShouldNotContain(deletedCsprojPath);
+            paths.ShouldContain(solutionPath);
+        }
+        finally
+        {
+            Directory.Delete(solutionDir, recursive: true);
+        }
+    }
 }

--- a/tests/TrackedFilesTests/CollectPaths.cs
+++ b/tests/TrackedFilesTests/CollectPaths.cs
@@ -1,0 +1,167 @@
+using Microsoft.CodeAnalysis;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.TrackedFilesTests;
+
+public sealed class CollectPaths
+{
+    [Fact]
+    public void AlwaysIncludesSolutionFilePath()
+    {
+        // Arrange
+        string solutionDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(solutionDir);
+
+        try
+        {
+            string solutionPath = Path.Combine(solutionDir, "Solution.sln");
+            File.WriteAllText(solutionPath, "");
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.CurrentSolution;
+
+            // Act
+            IReadOnlyList<string> paths = TrackedFiles.CollectPaths(solution, solutionDir, solutionPath);
+
+            // Assert
+            paths.ShouldContain(solutionPath);
+        }
+        finally
+        {
+            Directory.Delete(solutionDir, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData("Directory.Packages.props")]
+    [InlineData("Directory.Build.props")]
+    public void WhenPropsFileExistsInSolutionDirectory_IncludesIt(string propsFileName)
+    {
+        // Arrange
+        string solutionDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(solutionDir);
+
+        try
+        {
+            string propsPath = Path.Combine(solutionDir, propsFileName);
+            File.WriteAllText(propsPath, "<Project />");
+
+            string solutionPath = Path.Combine(solutionDir, "Solution.sln");
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.CurrentSolution;
+
+            // Act
+            IReadOnlyList<string> paths = TrackedFiles.CollectPaths(solution, solutionDir, solutionPath);
+
+            // Assert
+            paths.ShouldContain(propsPath);
+        }
+        finally
+        {
+            Directory.Delete(solutionDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenProjectHasNoFilePath_OnlyContainsSolutionFile()
+    {
+        // Arrange
+        string solutionDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(solutionDir);
+
+        try
+        {
+            string solutionPath = Path.Combine(solutionDir, "Solution.sln");
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.AddProject(ProjectInfo.Create(
+                ProjectId.CreateNewId(),
+                VersionStamp.Create(),
+                "Alpha",
+                "Alpha",
+                LanguageNames.CSharp,
+                filePath: null))
+                .Solution;
+
+            // Act
+            IReadOnlyList<string> paths = TrackedFiles.CollectPaths(solution, solutionDir, solutionPath);
+
+            // Assert — only the solution file itself, no csproj
+            paths.ShouldBe([solutionPath]);
+        }
+        finally
+        {
+            Directory.Delete(solutionDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenPropsFileExistsInParentDirectory_IncludesIt()
+    {
+        // Arrange
+        string rootDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        string solutionDir = Path.Combine(rootDir, "solution");
+        Directory.CreateDirectory(solutionDir);
+
+        try
+        {
+            string propsPath = Path.Combine(rootDir, "Directory.Packages.props");
+            File.WriteAllText(propsPath, "<Project />");
+
+            string solutionPath = Path.Combine(solutionDir, "Solution.sln");
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.CurrentSolution;
+
+            // Act
+            IReadOnlyList<string> paths = TrackedFiles.CollectPaths(solution, solutionDir, solutionPath);
+
+            // Assert
+            paths.ShouldContain(propsPath);
+        }
+        finally
+        {
+            Directory.Delete(rootDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WhenSolutionHasProjects_IncludesCsprojPaths()
+    {
+        // Arrange
+        string solutionDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(solutionDir);
+
+        try
+        {
+            string solutionPath = Path.Combine(solutionDir, "Solution.sln");
+            string csprojPath = Path.Combine(solutionDir, "Alpha", "Alpha.csproj");
+            Directory.CreateDirectory(Path.GetDirectoryName(csprojPath)!);
+            File.WriteAllText(csprojPath, "<Project />");
+
+            using AdhocWorkspace workspace = new();
+            Solution solution = workspace.AddProject(ProjectInfo.Create(
+                ProjectId.CreateNewId(),
+                VersionStamp.Create(),
+                "Alpha",
+                "Alpha",
+                LanguageNames.CSharp,
+                filePath: csprojPath))
+                .Solution;
+
+            // Act
+            IReadOnlyList<string> paths = TrackedFiles.CollectPaths(solution, solutionDir, solutionPath);
+
+            // Assert
+            paths.ShouldContain(csprojPath);
+        }
+        finally
+        {
+            Directory.Delete(solutionDir, recursive: true);
+        }
+    }
+}

--- a/tests/TrackedFilesTests/CollectPaths.cs
+++ b/tests/TrackedFilesTests/CollectPaths.cs
@@ -98,33 +98,24 @@ public sealed class CollectPaths
     public void WhenProjectHasNoFilePath_OnlyContainsSolutionFile()
     {
         // Arrange
-        string solutionDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(solutionDir);
+        string solutionPath = @"C:\repos\Solution.sln";
+        string solutionDir = @"C:\repos";
 
-        try
-        {
-            string solutionPath = Path.Combine(solutionDir, "Solution.sln");
+        using AdhocWorkspace workspace = new();
+        Solution solution = workspace.AddProject(ProjectInfo.Create(
+            ProjectId.CreateNewId(),
+            VersionStamp.Create(),
+            "Alpha",
+            "Alpha",
+            LanguageNames.CSharp,
+            filePath: null))
+            .Solution;
 
-            using AdhocWorkspace workspace = new();
-            Solution solution = workspace.AddProject(ProjectInfo.Create(
-                ProjectId.CreateNewId(),
-                VersionStamp.Create(),
-                "Alpha",
-                "Alpha",
-                LanguageNames.CSharp,
-                filePath: null))
-                .Solution;
+        // Act
+        IReadOnlyList<string> paths = TrackedFiles.CollectPaths(solution, solutionDir, solutionPath);
 
-            // Act
-            IReadOnlyList<string> paths = TrackedFiles.CollectPaths(solution, solutionDir, solutionPath);
-
-            // Assert
-            paths.ShouldBe([solutionPath]);
-        }
-        finally
-        {
-            Directory.Delete(solutionDir, recursive: true);
-        }
+        // Assert
+        paths.ShouldBe([solutionPath]);
     }
 
     [Fact]

--- a/tests/TrackedFilesTests/CollectPaths.cs
+++ b/tests/TrackedFilesTests/CollectPaths.cs
@@ -8,6 +8,34 @@ namespace roslyn_query.Tests.TrackedFilesTests;
 
 public sealed class CollectPaths
 {
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void WhenSolutionFilePathIsNullOrEmpty_Throws(string? solutionFilePath)
+    {
+        // Arrange
+        using AdhocWorkspace workspace = new();
+        Solution solution = workspace.CurrentSolution;
+
+        // Act / Assert
+        Should.Throw<ArgumentException>(
+            () => TrackedFiles.CollectPaths(solution, "dir", solutionFilePath!));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void WhenSolutionDirectoryIsNullOrEmpty_Throws(string? solutionDirectory)
+    {
+        // Arrange
+        using AdhocWorkspace workspace = new();
+        Solution solution = workspace.CurrentSolution;
+
+        // Act / Assert
+        Should.Throw<ArgumentException>(
+            () => TrackedFiles.CollectPaths(solution, solutionDirectory!, "Solution.sln"));
+    }
+
     [Fact]
     public void AlwaysIncludesSolutionFilePath()
     {

--- a/tests/TrackedFilesTests/ComputeMaxWriteTime.cs
+++ b/tests/TrackedFilesTests/ComputeMaxWriteTime.cs
@@ -1,0 +1,63 @@
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.TrackedFilesTests;
+
+public sealed class ComputeMaxWriteTime
+{
+    [Fact]
+    public void WhenPathsListIsEmpty_ReturnsMinValue()
+    {
+        // Act
+        DateTime result = TrackedFiles.ComputeMaxWriteTime([]);
+
+        // Assert
+        result.ShouldBe(DateTime.MinValue);
+    }
+
+    [Fact]
+    public void WhenFileIsMissing_ReturnsMaxValue()
+    {
+        // Arrange
+        string missingPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "Missing.csproj");
+
+        // Act
+        DateTime result = TrackedFiles.ComputeMaxWriteTime([missingPath]);
+
+        // Assert
+        result.ShouldBe(DateTime.MaxValue);
+    }
+
+    [Fact]
+    public void WhenMultipleFiles_ReturnsLatestWriteTime()
+    {
+        // Arrange
+        string dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        try
+        {
+            string fileA = Path.Combine(dir, "A.csproj");
+            string fileB = Path.Combine(dir, "B.csproj");
+
+            File.WriteAllText(fileA, "");
+            File.WriteAllText(fileB, "");
+
+            DateTime earlierTime = new(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            DateTime laterTime = new(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+            File.SetLastWriteTimeUtc(fileA, earlierTime);
+            File.SetLastWriteTimeUtc(fileB, laterTime);
+
+            // Act
+            DateTime result = TrackedFiles.ComputeMaxWriteTime([fileA, fileB]);
+
+            // Assert
+            result.ShouldBe(laterTime);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Expand daemon reload detection beyond the solution file to include `.csproj`, `packages.lock.json`, `Directory.Packages.props`, and `Directory.Build.props`
- Fix file I/O inside locks (`CompleteReload`, `IsStale`) by snapshotting state under the lock and computing outside
- Make staleness check atomic (`IsStaleAsync`) and async to avoid blocking the pipe server loop
- Add poll interval guard (2s) to skip redundant stat scans on rapid connections
- Filter non-existent project paths in `CollectPaths` to prevent reload loops on deleted files
- Bound `DiscoverPropsFiles` ancestor walk at git root (with 20-level hard cap)
- Pin `System.Security.Cryptography.Xml` to 9.0.15 to resolve transitive vulnerability

## Test plan

- [x] All 228 tests pass
- [x] New tests cover: `IsStaleAsync`, `CollectPaths` argument guards, deleted file filtering, `packages.lock.json` discovery, git-root walk bound, `MissingFileSentinel` detection

Closes #56