### PR TITLE
fix: filter deleted files from reference results

### DIFF
--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -617,14 +617,14 @@ public static class CommandDispatcher
             foreach (Location loc in allLocations)
             {
                 FileLinePositionSpan span = loc.GetLineSpan();
+                string? location = FormatLocation(span, context, loc.SourceTree, basePath);
+                if (location is null)
+                {
+                    continue;
+                }
                 string key = $"{span.Path}:{span.StartLinePosition.Line + 1}";
                 if (seen.Add(key))
                 {
-                    string? location = FormatLocation(span, context, loc.SourceTree, basePath);
-                    if (location is null)
-                    {
-                        continue;
-                    }
                     await ctx.Stdout.WriteLineAsync(location);
                     count++;
                 }
@@ -999,7 +999,7 @@ public static class CommandDispatcher
         {
             Location? loc = baseType.Locations.FirstOrDefault(l => l.IsInSource);
             string src = loc is not null
-                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, basePath) ?? "(external)"
+                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, basePath) ?? "(deleted)"
                 : "(external)";
             await ctx.Stdout.WriteLineAsync(
                 $"base\t{baseType.ToDisplayString()}\t{src}");
@@ -1010,7 +1010,7 @@ public static class CommandDispatcher
         {
             Location? loc = iface.Locations.FirstOrDefault(l => l.IsInSource);
             string src = loc is not null
-                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, basePath) ?? "(external)"
+                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, basePath) ?? "(deleted)"
                 : "(external)";
             await ctx.Stdout.WriteLineAsync(
                 $"interface\t{iface.ToDisplayString()}\t{src}");
@@ -1121,7 +1121,7 @@ public static class CommandDispatcher
                 targetLoc.GetLineSpan(),
                 context: false,
                 targetLoc.SourceTree,
-                basePath) ?? "(external)"
+                basePath) ?? "(deleted)"
             : "(external)";
         string kind = FormatTypeKind(target.TypeKind);
         await ctx.Stdout.WriteLineAsync(

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -282,7 +282,7 @@ public static class CommandDispatcher
             "(under 1 second after the first query).");
     }
 
-    private static string FormatLocation(
+    private static string? FormatLocation(
         FileLinePositionSpan span,
         bool context,
         SyntaxTree? tree,
@@ -515,8 +515,12 @@ public static class CommandDispatcher
                 }
 
                 FileLinePositionSpan span = loc.GetLineSpan();
-                await ctx.Stdout.WriteLineAsync(
-                    FormatLocation(span, context, loc.SourceTree, basePath));
+                string? location = FormatLocation(span, context, loc.SourceTree, basePath);
+                if (location is null)
+                {
+                    continue;
+                }
+                await ctx.Stdout.WriteLineAsync(location);
                 totalCount++;
             }
         }
@@ -565,7 +569,11 @@ public static class CommandDispatcher
                 continue;
             }
             FileLinePositionSpan span = loc.GetLineSpan();
-            string location = FormatLocation(span, context, loc.SourceTree, basePath);
+            string? location = FormatLocation(span, context, loc.SourceTree, basePath);
+            if (location is null)
+            {
+                continue;
+            }
             await ctx.Stdout.WriteLineAsync($"{location}\t{impl.ToDisplayString()}");
         }
 
@@ -612,8 +620,12 @@ public static class CommandDispatcher
                 string key = $"{span.Path}:{span.StartLinePosition.Line + 1}";
                 if (seen.Add(key))
                 {
-                    await ctx.Stdout.WriteLineAsync(
-                        FormatLocation(span, context, loc.SourceTree, basePath));
+                    string? location = FormatLocation(span, context, loc.SourceTree, basePath);
+                    if (location is null)
+                    {
+                        continue;
+                    }
+                    await ctx.Stdout.WriteLineAsync(location);
                     count++;
                 }
             }
@@ -692,7 +704,11 @@ public static class CommandDispatcher
                     continue;
                 }
                 FileLinePositionSpan span = loc.GetLineSpan();
-                string location = FormatLocation(span, context, loc.SourceTree, basePath);
+                string? location = FormatLocation(span, context, loc.SourceTree, basePath);
+                if (location is null)
+                {
+                    continue;
+                }
                 await ctx.Stdout.WriteLineAsync(
                     $"{location}\t{FormatSymbolName(o, compact)}");
             }
@@ -737,7 +753,11 @@ public static class CommandDispatcher
 
         foreach (AttributeMatch result in results)
         {
-            string location = FormatLocation(result.Span, context, result.Tree, basePath);
+            string? location = FormatLocation(result.Span, context, result.Tree, basePath);
+            if (location is null)
+            {
+                continue;
+            }
             await ctx.Stdout.WriteLineAsync($"{location}\t{result.FullyQualifiedName}");
         }
 
@@ -804,11 +824,15 @@ public static class CommandDispatcher
                 foreach (Location location in caller.Locations)
                 {
                     FileLinePositionSpan span = location.GetLineSpan();
-                    string formatted = FormatLocation(
+                    string? formatted = FormatLocation(
                         span,
                         context,
                         location.SourceTree,
                         basePath);
+                    if (formatted is null)
+                    {
+                        continue;
+                    }
                     await ctx.Stdout.WriteLineAsync(
                         $"{formatted}\t{FormatSymbolName(caller.CallingSymbol, compact)}");
                     totalCount++;
@@ -878,11 +902,15 @@ public static class CommandDispatcher
 
         foreach (UnusedSymbolMatch match in results)
         {
-            string location = FormatLocation(
+            string? location = FormatLocation(
                 match.Span,
                 context,
                 match.Tree,
                 basePath);
+            if (location is null)
+            {
+                continue;
+            }
             await ctx.Stdout.WriteLineAsync(
                 $"{location}\t{match.DisplayName}");
         }
@@ -971,7 +999,7 @@ public static class CommandDispatcher
         {
             Location? loc = baseType.Locations.FirstOrDefault(l => l.IsInSource);
             string src = loc is not null
-                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, basePath)
+                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, basePath) ?? "(external)"
                 : "(external)";
             await ctx.Stdout.WriteLineAsync(
                 $"base\t{baseType.ToDisplayString()}\t{src}");
@@ -982,7 +1010,7 @@ public static class CommandDispatcher
         {
             Location? loc = iface.Locations.FirstOrDefault(l => l.IsInSource);
             string src = loc is not null
-                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, basePath)
+                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, basePath) ?? "(external)"
                 : "(external)";
             await ctx.Stdout.WriteLineAsync(
                 $"interface\t{iface.ToDisplayString()}\t{src}");
@@ -1093,7 +1121,7 @@ public static class CommandDispatcher
                 targetLoc.GetLineSpan(),
                 context: false,
                 targetLoc.SourceTree,
-                basePath)
+                basePath) ?? "(external)"
             : "(external)";
         string kind = FormatTypeKind(target.TypeKind);
         await ctx.Stdout.WriteLineAsync(
@@ -1232,7 +1260,11 @@ public static class CommandDispatcher
                 }
 
                 FileLinePositionSpan span = loc.GetLineSpan();
-                string location = FormatLocation(span, context, loc.SourceTree, basePath);
+                string? location = FormatLocation(span, context, loc.SourceTree, basePath);
+                if (location is null)
+                {
+                    continue;
+                }
                 string typeKind = FormatTypeKind(type.TypeKind);
                 await ctx.Stdout.WriteLineAsync(
                     $"{typeKind}\t{type.ToDisplayString()}\t{location}");

--- a/src/LocationFormatter.cs
+++ b/src/LocationFormatter.cs
@@ -5,12 +5,19 @@ namespace RoslynQuery;
 
 public static class LocationFormatter
 {
-    public static string Format(
+    public static string? Format(
         FileLinePositionSpan span,
         bool context,
         SyntaxTree? tree,
         string? basePath = null)
     {
+        if (!string.IsNullOrEmpty(span.Path)
+            && Path.IsPathRooted(span.Path)
+            && !File.Exists(span.Path))
+        {
+            return null;
+        }
+
         string path = basePath is not null
             ? Path.GetRelativePath(basePath, span.Path)
             : span.Path;

--- a/tests/CommandDispatcherTests/DescribeCommand.cs
+++ b/tests/CommandDispatcherTests/DescribeCommand.cs
@@ -285,31 +285,39 @@ enum Color { Red, Green, Blue }";
     public async Task WhenAbsoluteFlag_OutputsAbsolutePath()
     {
         // Arrange
-        string absolutePath = Path.Combine(
-            Path.GetTempPath(), "myapp", "src", "Test.cs");
-        string solutionDir = Path.Combine(
-            Path.GetTempPath(), "myapp");
+        string tempDir = Path.Combine(Path.GetTempPath(), $"rq-desc-{Guid.NewGuid()}");
+        string srcDir = Path.Combine(tempDir, "src");
+        string absolutePath = Path.Combine(srcDir, "Test.cs");
         string source = @"
 namespace App;
 class MyService { }";
-        Solution solution = CreateSolution(source, absolutePath);
-        StringWriter stdout = new();
-        StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution, solutionDir);
+        Directory.CreateDirectory(srcDir);
+        await File.WriteAllTextAsync(absolutePath, source);
+        try
+        {
+            Solution solution = CreateSolution(source, absolutePath);
+            StringWriter stdout = new();
+            StringWriter stderr = new();
+            CommandContext context = new(stdout, stderr, solution, tempDir);
 
-        // Act
-        int exitCode = await CommandDispatcher.ExecuteAsync(
-            ["describe", "MyService", "--absolute"],
-            context);
+            // Act
+            int exitCode = await CommandDispatcher.ExecuteAsync(
+                ["describe", "MyService", "--absolute"],
+                context);
 
-        // Assert
-        exitCode.ShouldBe(0);
-        string[] lines = stdout.ToString().TrimEnd().Split(Environment.NewLine);
-        string headerLine = lines[0];
-        headerLine.ShouldContain(absolutePath);
-        string locationPart = headerLine.Split("  ")[1];
-        string pathPart = locationPart[..locationPart.LastIndexOf(':')];
-        Path.IsPathRooted(pathPart).ShouldBeTrue();
+            // Assert
+            exitCode.ShouldBe(0);
+            string[] lines = stdout.ToString().TrimEnd().Split(Environment.NewLine);
+            string headerLine = lines[0];
+            headerLine.ShouldContain(absolutePath);
+            string locationPart = headerLine.Split("  ")[1];
+            string pathPart = locationPart[..locationPart.LastIndexOf(':')];
+            Path.IsPathRooted(pathPart).ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]

--- a/tests/CommandDispatcherTests/DescribeCommand.cs
+++ b/tests/CommandDispatcherTests/DescribeCommand.cs
@@ -298,21 +298,25 @@ class MyService { }";
         StringWriter stderr = new();
         CommandContext context = new(stdout, stderr, solution, tempDir);
 
-        // Act
-        int exitCode = await CommandDispatcher.ExecuteAsync(
-            ["describe", "MyService", "--absolute"],
-            context);
+        // Act & Assert
+        try
+        {
+            int exitCode = await CommandDispatcher.ExecuteAsync(
+                ["describe", "MyService", "--absolute"],
+                context);
 
-        // Assert
-        exitCode.ShouldBe(0);
-        string[] lines = stdout.ToString().TrimEnd().Split(Environment.NewLine);
-        string headerLine = lines[0];
-        headerLine.ShouldContain(absolutePath);
-        string locationPart = headerLine.Split("  ")[1];
-        string pathPart = locationPart[..locationPart.LastIndexOf(':')];
-        Path.IsPathRooted(pathPart).ShouldBeTrue();
-
-        Directory.Delete(tempDir, recursive: true);
+            exitCode.ShouldBe(0);
+            string[] lines = stdout.ToString().TrimEnd().Split(Environment.NewLine);
+            string headerLine = lines[0];
+            headerLine.ShouldContain(absolutePath);
+            string locationPart = headerLine.Split("  ")[1];
+            string pathPart = locationPart[..locationPart.LastIndexOf(':')];
+            Path.IsPathRooted(pathPart).ShouldBeTrue();
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
     }
 
     [Fact]

--- a/tests/CommandDispatcherTests/DescribeCommand.cs
+++ b/tests/CommandDispatcherTests/DescribeCommand.cs
@@ -293,31 +293,26 @@ namespace App;
 class MyService { }";
         Directory.CreateDirectory(srcDir);
         await File.WriteAllTextAsync(absolutePath, source);
-        try
-        {
-            Solution solution = CreateSolution(source, absolutePath);
-            StringWriter stdout = new();
-            StringWriter stderr = new();
-            CommandContext context = new(stdout, stderr, solution, tempDir);
+        Solution solution = CreateSolution(source, absolutePath);
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        CommandContext context = new(stdout, stderr, solution, tempDir);
 
-            // Act
-            int exitCode = await CommandDispatcher.ExecuteAsync(
-                ["describe", "MyService", "--absolute"],
-                context);
+        // Act
+        int exitCode = await CommandDispatcher.ExecuteAsync(
+            ["describe", "MyService", "--absolute"],
+            context);
 
-            // Assert
-            exitCode.ShouldBe(0);
-            string[] lines = stdout.ToString().TrimEnd().Split(Environment.NewLine);
-            string headerLine = lines[0];
-            headerLine.ShouldContain(absolutePath);
-            string locationPart = headerLine.Split("  ")[1];
-            string pathPart = locationPart[..locationPart.LastIndexOf(':')];
-            Path.IsPathRooted(pathPart).ShouldBeTrue();
-        }
-        finally
-        {
-            Directory.Delete(tempDir, recursive: true);
-        }
+        // Assert
+        exitCode.ShouldBe(0);
+        string[] lines = stdout.ToString().TrimEnd().Split(Environment.NewLine);
+        string headerLine = lines[0];
+        headerLine.ShouldContain(absolutePath);
+        string locationPart = headerLine.Split("  ")[1];
+        string pathPart = locationPart[..locationPart.LastIndexOf(':')];
+        Path.IsPathRooted(pathPart).ShouldBeTrue();
+
+        Directory.Delete(tempDir, recursive: true);
     }
 
     [Fact]

--- a/tests/LocationFormatterTests/Format.cs
+++ b/tests/LocationFormatterTests/Format.cs
@@ -136,30 +136,6 @@ public sealed class Format
     }
 
     [Fact]
-    public void WhenPathExistsOnDisk_FormatsNormally()
-    {
-        // Arrange
-        string existingPath = Path.GetTempFileName();
-        try
-        {
-            FileLinePositionSpan span = new(
-                existingPath,
-                new LinePosition(0, 0),
-                new LinePosition(0, 5));
-
-            // Act
-            string? result = LocationFormatter.Format(span, context: false, tree: null);
-
-            // Assert
-            result.ShouldBe($"{existingPath}:1");
-        }
-        finally
-        {
-            File.Delete(existingPath);
-        }
-    }
-
-    [Fact]
     public void WhenPathIsRelativeAndDoesNotExist_FormatsNormally()
     {
         // Arrange

--- a/tests/LocationFormatterTests/Format.cs
+++ b/tests/LocationFormatterTests/Format.cs
@@ -158,4 +158,22 @@ public sealed class Format
             File.Delete(existingPath);
         }
     }
+
+    [Fact]
+    public void WhenPathIsRelativeAndDoesNotExist_FormatsNormally()
+    {
+        // Arrange
+        // Relative paths are not checked for existence — only absolute paths are filtered.
+        // This documents the intentional Path.IsPathRooted guard in LocationFormatter.Format.
+        FileLinePositionSpan span = new(
+            @"src/Missing.cs",
+            new LinePosition(0, 0),
+            new LinePosition(0, 5));
+
+        // Act
+        string? result = LocationFormatter.Format(span, context: false, tree: null);
+
+        // Assert
+        result.ShouldBe(@"src/Missing.cs:1");
+    }
 }

--- a/tests/LocationFormatterTests/Format.cs
+++ b/tests/LocationFormatterTests/Format.cs
@@ -24,7 +24,7 @@ public sealed class Format
             .GetLineSpan();
 
         // Act
-        string result = LocationFormatter.Format(span, context: false, tree);
+        string? result = LocationFormatter.Format(span, context: false, tree);
 
         // Assert
         result.ShouldBe($"{TestFilePath}:1");
@@ -40,7 +40,7 @@ public sealed class Format
             new LinePosition(0, 5));
 
         // Act
-        string result = LocationFormatter.Format(span, context: true, tree: null);
+        string? result = LocationFormatter.Format(span, context: true, tree: null);
 
         // Assert
         result.ShouldBe($"{TestFilePath}:1");
@@ -57,7 +57,7 @@ public sealed class Format
             .GetLineSpan();
 
         // Act
-        string result = LocationFormatter.Format(span, context: true, tree);
+        string? result = LocationFormatter.Format(span, context: true, tree);
 
         // Assert
         result.ShouldBe($"{TestFilePath}:1\tclass Foo {{ }}");
@@ -75,7 +75,7 @@ public sealed class Format
             new LinePosition(3, 18));
 
         // Act
-        string result = LocationFormatter.Format(span, context: true, tree);
+        string? result = LocationFormatter.Format(span, context: true, tree);
 
         // Assert
         result.ShouldBe($"{TestFilePath}:4\tclass Bar {{ }}");
@@ -94,9 +94,68 @@ public sealed class Format
             new LinePosition(99, 5));
 
         // Act
-        string result = LocationFormatter.Format(span, context: true, tree);
+        string? result = LocationFormatter.Format(span, context: true, tree);
 
         // Assert
         result.ShouldBe($"{TestFilePath}:100");
+    }
+
+    [Fact]
+    public void WhenPathIsNonEmptyAndFileDoesNotExist_ReturnsNull()
+    {
+        // Arrange
+        string nonExistentPath = Path.Combine(
+            Path.GetTempPath(),
+            $"{Guid.NewGuid()}.cs");
+        FileLinePositionSpan span = new(
+            nonExistentPath,
+            new LinePosition(0, 0),
+            new LinePosition(0, 5));
+
+        // Act
+        string? result = LocationFormatter.Format(span, context: false, tree: null);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void WhenPathIsEmpty_FormatsNormally()
+    {
+        // Arrange
+        FileLinePositionSpan span = new(
+            "",
+            new LinePosition(0, 0),
+            new LinePosition(0, 5));
+
+        // Act
+        string? result = LocationFormatter.Format(span, context: false, tree: null);
+
+        // Assert
+        result.ShouldBe(":1");
+    }
+
+    [Fact]
+    public void WhenPathExistsOnDisk_FormatsNormally()
+    {
+        // Arrange
+        string existingPath = Path.GetTempFileName();
+        try
+        {
+            FileLinePositionSpan span = new(
+                existingPath,
+                new LinePosition(0, 0),
+                new LinePosition(0, 5));
+
+            // Act
+            string? result = LocationFormatter.Format(span, context: false, tree: null);
+
+            // Assert
+            result.ShouldBe($"{existingPath}:1");
+        }
+        finally
+        {
+            File.Delete(existingPath);
+        }
     }
 }

--- a/tests/LocationFormatterTests/FormatWithBasePath.cs
+++ b/tests/LocationFormatterTests/FormatWithBasePath.cs
@@ -7,27 +7,42 @@ using Shouldly;
 
 namespace roslyn_query.Tests.LocationFormatterTests;
 
-public sealed class FormatWithBasePath
+public sealed class FormatWithBasePath : IDisposable
 {
+    private readonly string _tempDir;
+    private readonly string _absolutePath;
+
+    public FormatWithBasePath()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"rq-tests-{Guid.NewGuid()}");
+        string srcDir = Path.Combine(_tempDir, "src");
+        Directory.CreateDirectory(srcDir);
+        _absolutePath = Path.Combine(srcDir, "Foo.cs");
+        File.WriteAllText(_absolutePath, "class Foo { }");
+    }
+
+    public void Dispose()
+    {
+        Directory.Delete(_tempDir, recursive: true);
+    }
+
     [Fact]
     public void WhenBasePathProvided_ReturnsRelativePath()
     {
         // Arrange
-        string absolutePath = Path.Combine("C:", "projects", "myapp", "src", "Foo.cs");
-        string basePath = Path.Combine("C:", "projects", "myapp");
         SyntaxTree tree = CSharpSyntaxTree.ParseText(
             "class Foo { }",
-            path: absolutePath);
+            path: _absolutePath);
         FileLinePositionSpan span = tree.GetRoot()
             .GetLocation()
             .GetLineSpan();
 
         // Act
-        string result = LocationFormatter.Format(
+        string? result = LocationFormatter.Format(
             span,
             context: false,
             tree,
-            basePath: basePath);
+            basePath: _tempDir);
 
         // Assert
         string expected = Path.Combine("src", "Foo.cs");
@@ -38,43 +53,41 @@ public sealed class FormatWithBasePath
     public void WhenBasePathIsNull_ReturnsAbsolutePath()
     {
         // Arrange
-        string absolutePath = Path.Combine("C:", "projects", "myapp", "src", "Foo.cs");
         SyntaxTree tree = CSharpSyntaxTree.ParseText(
             "class Foo { }",
-            path: absolutePath);
+            path: _absolutePath);
         FileLinePositionSpan span = tree.GetRoot()
             .GetLocation()
             .GetLineSpan();
 
         // Act
-        string result = LocationFormatter.Format(
+        string? result = LocationFormatter.Format(
             span,
             context: false,
             tree,
             basePath: null);
 
         // Assert
-        result.ShouldBe($"{absolutePath}:1");
+        result.ShouldBe($"{_absolutePath}:1");
     }
 
     [Fact]
     public void WhenBasePathProvidedWithContext_ReturnsRelativePathWithSourceLine()
     {
         // Arrange
-        string absolutePath = Path.Combine("C:", "projects", "myapp", "src", "Foo.cs");
-        string basePath = Path.Combine("C:", "projects", "myapp");
         string source = "    class Foo { }";
-        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, path: absolutePath);
+        File.WriteAllText(_absolutePath, source);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, path: _absolutePath);
         FileLinePositionSpan span = tree.GetRoot()
             .GetLocation()
             .GetLineSpan();
 
         // Act
-        string result = LocationFormatter.Format(
+        string? result = LocationFormatter.Format(
             span,
             context: true,
             tree,
-            basePath: basePath);
+            basePath: _tempDir);
 
         // Assert
         string expected = Path.Combine("src", "Foo.cs");

--- a/tests/LocationFormatterTests/FormatWithBasePath.cs
+++ b/tests/LocationFormatterTests/FormatWithBasePath.cs
@@ -1,5 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
 
 using RoslynQuery;
 
@@ -24,6 +25,23 @@ public sealed class FormatWithBasePath : IDisposable
     public void Dispose()
     {
         Directory.Delete(_tempDir, recursive: true);
+    }
+
+    [Fact]
+    public void WhenPathExistsOnDisk_FormatsNormally()
+    {
+        // Arrange
+        FileLinePositionSpan span = new(
+            _absolutePath,
+            new LinePosition(0, 0),
+            new LinePosition(0, 5));
+
+        // Act
+        string? result = LocationFormatter.Format(span, context: false, tree: null);
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.ShouldBe($"{_absolutePath}:1");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Add `File.Exists` guard in `LocationFormatter.Format()` to silently omit locations pointing to deleted files
- Change return type to `string?`; all 8 location-emitting commands skip null results
- Use `"(deleted)"` sentinel (distinct from `"(external)"`) for commands that need a fallback label
- Fix dedup ordering in find-ctors so deleted-file keys don't poison the `seen` set

Closes #60

## Test plan

- [x] `WhenPathIsNonEmptyAndFileDoesNotExist_ReturnsNull` — absolute path to non-existent file returns null
- [x] `WhenPathIsRelativeAndDoesNotExist_FormatsNormally` — relative paths bypass the guard
- [x] `WhenPathExistsOnDisk_FormatsNormally` — existing file formats unchanged
- [x] `WhenPathIsEmpty_FormatsNormally` — empty path passes through
- [x] All 244 tests pass