### PR TITLE
refactor: replace File.Exists with frozen workspace document set

### DIFF
--- a/src/CommandContext.cs
+++ b/src/CommandContext.cs
@@ -1,3 +1,5 @@
+using System.Collections.Frozen;
+
 using Microsoft.CodeAnalysis;
 
 namespace RoslynQuery;
@@ -6,10 +8,12 @@ public sealed class CommandContext(
     TextWriter stdout,
     TextWriter stderr,
     Solution solution,
-    string solutionDirectory = "")
+    string solutionDirectory = "",
+    FrozenSet<string>? documentPaths = null)
 {
     public TextWriter Stdout { get; } = stdout;
     public TextWriter Stderr { get; } = stderr;
     public Solution Solution { get; } = solution;
     public string SolutionDirectory { get; } = solutionDirectory;
+    public FrozenSet<string> DocumentPaths { get; } = documentPaths ?? FrozenSet<string>.Empty;
 }

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -139,7 +139,8 @@ public static class CommandDispatcher
                 countingWriter,
                 TextWriter.Null,
                 context.Solution,
-                context.SolutionDirectory);
+                context.SolutionDirectory,
+                context.DocumentPaths);
         }
         else if (limit > 0)
         {
@@ -148,7 +149,8 @@ public static class CommandDispatcher
                 limitedWriter,
                 context.Stderr,
                 context.Solution,
-                context.SolutionDirectory);
+                context.SolutionDirectory,
+                context.DocumentPaths);
         }
 
         if (inProject is not null)
@@ -176,7 +178,8 @@ public static class CommandDispatcher
                     solutionDirectory),
                 effectiveContext.Stderr,
                 effectiveContext.Solution,
-                effectiveContext.SolutionDirectory);
+                effectiveContext.SolutionDirectory,
+                effectiveContext.DocumentPaths);
         }
 
         int result = command switch

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -292,7 +292,7 @@ public static class CommandDispatcher
             span,
             context,
             tree,
-            TrackedFiles.CollectDocumentPaths(ctx.Solution),
+            ctx.DocumentPaths,
             basePath);
 
     private static string FormatTypeKind(TypeKind kind) => kind switch
@@ -1007,7 +1007,7 @@ public static class CommandDispatcher
         {
             Location? loc = baseType.Locations.FirstOrDefault(l => l.IsInSource);
             string src = loc is not null
-                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, ctx, basePath) ?? "(deleted)"
+                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, ctx, basePath) ?? "(external)"
                 : "(external)";
             await ctx.Stdout.WriteLineAsync(
                 $"base\t{baseType.ToDisplayString()}\t{src}");
@@ -1018,7 +1018,7 @@ public static class CommandDispatcher
         {
             Location? loc = iface.Locations.FirstOrDefault(l => l.IsInSource);
             string src = loc is not null
-                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, ctx, basePath) ?? "(deleted)"
+                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, ctx, basePath) ?? "(external)"
                 : "(external)";
             await ctx.Stdout.WriteLineAsync(
                 $"interface\t{iface.ToDisplayString()}\t{src}");
@@ -1130,7 +1130,7 @@ public static class CommandDispatcher
                 context: false,
                 targetLoc.SourceTree,
                 ctx,
-                basePath) ?? "(deleted)"
+                basePath) ?? "(external)"
             : "(external)";
         string kind = FormatTypeKind(target.TypeKind);
         await ctx.Stdout.WriteLineAsync(

--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -286,8 +286,14 @@ public static class CommandDispatcher
         FileLinePositionSpan span,
         bool context,
         SyntaxTree? tree,
+        CommandContext ctx,
         string? basePath = null)
-        => LocationFormatter.Format(span, context, tree, basePath);
+        => LocationFormatter.Format(
+            span,
+            context,
+            tree,
+            TrackedFiles.CollectDocumentPaths(ctx.Solution),
+            basePath);
 
     private static string FormatTypeKind(TypeKind kind) => kind switch
     {
@@ -515,7 +521,7 @@ public static class CommandDispatcher
                 }
 
                 FileLinePositionSpan span = loc.GetLineSpan();
-                string? location = FormatLocation(span, context, loc.SourceTree, basePath);
+                string? location = FormatLocation(span, context, loc.SourceTree, ctx, basePath);
                 if (location is null)
                 {
                     continue;
@@ -569,7 +575,7 @@ public static class CommandDispatcher
                 continue;
             }
             FileLinePositionSpan span = loc.GetLineSpan();
-            string? location = FormatLocation(span, context, loc.SourceTree, basePath);
+            string? location = FormatLocation(span, context, loc.SourceTree, ctx, basePath);
             if (location is null)
             {
                 continue;
@@ -617,7 +623,7 @@ public static class CommandDispatcher
             foreach (Location loc in allLocations)
             {
                 FileLinePositionSpan span = loc.GetLineSpan();
-                string? location = FormatLocation(span, context, loc.SourceTree, basePath);
+                string? location = FormatLocation(span, context, loc.SourceTree, ctx, basePath);
                 if (location is null)
                 {
                     continue;
@@ -704,7 +710,7 @@ public static class CommandDispatcher
                     continue;
                 }
                 FileLinePositionSpan span = loc.GetLineSpan();
-                string? location = FormatLocation(span, context, loc.SourceTree, basePath);
+                string? location = FormatLocation(span, context, loc.SourceTree, ctx, basePath);
                 if (location is null)
                 {
                     continue;
@@ -753,7 +759,7 @@ public static class CommandDispatcher
 
         foreach (AttributeMatch result in results)
         {
-            string? location = FormatLocation(result.Span, context, result.Tree, basePath);
+            string? location = FormatLocation(result.Span, context, result.Tree, ctx, basePath);
             if (location is null)
             {
                 continue;
@@ -828,6 +834,7 @@ public static class CommandDispatcher
                         span,
                         context,
                         location.SourceTree,
+                        ctx,
                         basePath);
                     if (formatted is null)
                     {
@@ -906,6 +913,7 @@ public static class CommandDispatcher
                 match.Span,
                 context,
                 match.Tree,
+                ctx,
                 basePath);
             if (location is null)
             {
@@ -999,7 +1007,7 @@ public static class CommandDispatcher
         {
             Location? loc = baseType.Locations.FirstOrDefault(l => l.IsInSource);
             string src = loc is not null
-                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, basePath) ?? "(deleted)"
+                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, ctx, basePath) ?? "(deleted)"
                 : "(external)";
             await ctx.Stdout.WriteLineAsync(
                 $"base\t{baseType.ToDisplayString()}\t{src}");
@@ -1010,7 +1018,7 @@ public static class CommandDispatcher
         {
             Location? loc = iface.Locations.FirstOrDefault(l => l.IsInSource);
             string src = loc is not null
-                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, basePath) ?? "(deleted)"
+                ? FormatLocation(loc.GetLineSpan(), context: false, loc.SourceTree, ctx, basePath) ?? "(deleted)"
                 : "(external)";
             await ctx.Stdout.WriteLineAsync(
                 $"interface\t{iface.ToDisplayString()}\t{src}");
@@ -1121,6 +1129,7 @@ public static class CommandDispatcher
                 targetLoc.GetLineSpan(),
                 context: false,
                 targetLoc.SourceTree,
+                ctx,
                 basePath) ?? "(deleted)"
             : "(external)";
         string kind = FormatTypeKind(target.TypeKind);
@@ -1260,7 +1269,7 @@ public static class CommandDispatcher
                 }
 
                 FileLinePositionSpan span = loc.GetLineSpan();
-                string? location = FormatLocation(span, context, loc.SourceTree, basePath);
+                string? location = FormatLocation(span, context, loc.SourceTree, ctx, basePath);
                 if (location is null)
                 {
                     continue;

--- a/src/DaemonServer.cs
+++ b/src/DaemonServer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.IO.Pipes;
 using System.Runtime.InteropServices;
 using System.Security.AccessControl;
@@ -48,7 +49,9 @@ public static class DaemonServer
             workspace.CurrentSolution,
             solutionDirectory,
             solutionPath);
-        ReloadState reloadState = new(workspace.CurrentSolution, initialTrackedPaths);
+        FrozenSet<string> initialDocumentPaths =
+            TrackedFiles.CollectDocumentPaths(workspace.CurrentSolution);
+        ReloadState reloadState = new(workspace.CurrentSolution, initialTrackedPaths, initialDocumentPaths);
         DateTime lastStalenessCheck = DateTime.MinValue;
 
         ApplyUnixPipeUmask();
@@ -107,9 +110,12 @@ public static class DaemonServer
                                             workspace.CurrentSolution,
                                             solutionDirectory,
                                             solutionPath);
+                                        FrozenSet<string> reloadedDocumentPaths =
+                                            TrackedFiles.CollectDocumentPaths(workspace.CurrentSolution);
                                         reloadState.CompleteReload(
                                             workspace.CurrentSolution,
-                                            reloadedPaths);
+                                            reloadedPaths,
+                                            reloadedDocumentPaths);
                                     }
 #pragma warning disable CA1031 // Abort reload on any failure to avoid stuck state
                                     catch
@@ -130,7 +136,8 @@ public static class DaemonServer
                         stdoutWriter,
                         stderrWriter,
                         reloadState.Solution,
-                        solutionDirectory);
+                        solutionDirectory,
+                        reloadState.DocumentPaths);
 
                     bool queryTimedOut = false;
                     int exitCode = 0;

--- a/src/LocationFormatter.cs
+++ b/src/LocationFormatter.cs
@@ -1,3 +1,5 @@
+using System.Collections.Frozen;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
@@ -9,11 +11,14 @@ public static class LocationFormatter
         FileLinePositionSpan span,
         bool context,
         SyntaxTree? tree,
+        FrozenSet<string> documentPaths,
         string? basePath = null)
     {
+        ArgumentNullException.ThrowIfNull(documentPaths);
+
         if (!string.IsNullOrEmpty(span.Path)
             && Path.IsPathRooted(span.Path)
-            && !File.Exists(span.Path))
+            && !documentPaths.Contains(span.Path))
         {
             return null;
         }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,3 +1,5 @@
+using System.Collections.Frozen;
+
 using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis.MSBuild;
 
@@ -234,11 +236,13 @@ static async Task<int> RunDirect(string solutionPath, string[] args, bool quiet)
 {
     using MSBuildWorkspace workspace = await OpenWorkspace(solutionPath, quiet);
     string solutionDirectory = Path.GetDirectoryName(solutionPath) ?? "";
+    FrozenSet<string> documentPaths = TrackedFiles.CollectDocumentPaths(workspace.CurrentSolution);
     CommandContext context = new(
         Console.Out,
         Console.Error,
         workspace.CurrentSolution,
-        solutionDirectory);
+        solutionDirectory,
+        documentPaths);
     return await CommandDispatcher.ExecuteAsync(args, context);
 }
 

--- a/src/ReloadState.cs
+++ b/src/ReloadState.cs
@@ -1,3 +1,5 @@
+using System.Collections.Frozen;
+
 using Microsoft.CodeAnalysis;
 
 namespace RoslynQuery;
@@ -7,16 +9,21 @@ public sealed class ReloadState
     private readonly Lock _lock = new();
     private Solution _solution;
     private IReadOnlyList<string> _trackedPaths;
+    private FrozenSet<string> _documentPaths;
     private DateTime _lastWriteTime;
     private bool _reloading;
 
-    public ReloadState(Solution solution, IReadOnlyList<string> trackedPaths)
+    public ReloadState(
+        Solution solution,
+        IReadOnlyList<string> trackedPaths,
+        FrozenSet<string>? documentPaths = null)
     {
         ArgumentNullException.ThrowIfNull(solution);
         ArgumentNullException.ThrowIfNull(trackedPaths);
 
         _solution = solution;
         _trackedPaths = trackedPaths;
+        _documentPaths = documentPaths ?? FrozenSet<string>.Empty;
         _lastWriteTime = TrackedFiles.ComputeMaxWriteTime(trackedPaths);
     }
 
@@ -38,6 +45,17 @@ public sealed class ReloadState
             lock (_lock)
             {
                 return _trackedPaths;
+            }
+        }
+    }
+
+    public FrozenSet<string> DocumentPaths
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _documentPaths;
             }
         }
     }
@@ -82,7 +100,10 @@ public sealed class ReloadState
         }
     }
 
-    public void CompleteReload(Solution solution, IReadOnlyList<string> trackedPaths)
+    public void CompleteReload(
+        Solution solution,
+        IReadOnlyList<string> trackedPaths,
+        FrozenSet<string>? documentPaths = null)
     {
         ArgumentNullException.ThrowIfNull(solution);
         ArgumentNullException.ThrowIfNull(trackedPaths);
@@ -93,6 +114,7 @@ public sealed class ReloadState
         {
             _solution = solution;
             _trackedPaths = trackedPaths;
+            _documentPaths = documentPaths ?? FrozenSet<string>.Empty;
             _lastWriteTime = lastWriteTime;
             _reloading = false;
         }

--- a/src/ReloadState.cs
+++ b/src/ReloadState.cs
@@ -103,10 +103,11 @@ public sealed class ReloadState
     public void CompleteReload(
         Solution solution,
         IReadOnlyList<string> trackedPaths,
-        FrozenSet<string>? documentPaths = null)
+        FrozenSet<string> documentPaths)
     {
         ArgumentNullException.ThrowIfNull(solution);
         ArgumentNullException.ThrowIfNull(trackedPaths);
+        ArgumentNullException.ThrowIfNull(documentPaths);
 
         DateTime lastWriteTime = TrackedFiles.ComputeMaxWriteTime(trackedPaths);
 
@@ -114,7 +115,7 @@ public sealed class ReloadState
         {
             _solution = solution;
             _trackedPaths = trackedPaths;
-            _documentPaths = documentPaths ?? FrozenSet<string>.Empty;
+            _documentPaths = documentPaths;
             _lastWriteTime = lastWriteTime;
             _reloading = false;
         }

--- a/src/TrackedFiles.cs
+++ b/src/TrackedFiles.cs
@@ -19,7 +19,8 @@ public static class TrackedFiles
             .SelectMany(p => p.Documents)
             .Select(d => d.FilePath)
             .Where(p => p is not null)
-            .ToFrozenSet(StringComparer.OrdinalIgnoreCase)!;
+            .Select(p => p!)
+            .ToFrozenSet(StringComparer.OrdinalIgnoreCase);
     }
 
     public static IReadOnlyList<string> CollectPaths(

--- a/src/TrackedFiles.cs
+++ b/src/TrackedFiles.cs
@@ -1,3 +1,5 @@
+using System.Collections.Frozen;
+
 using Microsoft.CodeAnalysis;
 
 namespace RoslynQuery;
@@ -8,6 +10,17 @@ public static class TrackedFiles
         ["Directory.Packages.props", "Directory.Build.props"];
 
     private static readonly DateTime MissingFileSentinel = DateTime.FromFileTimeUtc(0);
+
+    public static FrozenSet<string> CollectDocumentPaths(Solution solution)
+    {
+        ArgumentNullException.ThrowIfNull(solution);
+
+        return solution.Projects
+            .SelectMany(p => p.Documents)
+            .Select(d => d.FilePath)
+            .Where(p => p is not null)
+            .ToFrozenSet(StringComparer.OrdinalIgnoreCase)!;
+    }
 
     public static IReadOnlyList<string> CollectPaths(
         Solution solution,

--- a/tests/CommandContextTests/Constructor.cs
+++ b/tests/CommandContextTests/Constructor.cs
@@ -24,4 +24,19 @@ public sealed class Constructor
         context.Stderr.ShouldBeSameAs(stderr);
         context.Solution.ShouldBeNull();
     }
+
+    [Fact]
+    public void WhenCreatedWithoutDocumentPaths_DocumentPathsIsEmpty()
+    {
+        // Arrange
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        Solution solution = null!;
+
+        // Act
+        CommandContext context = new(stdout, stderr, solution);
+
+        // Assert
+        context.DocumentPaths.ShouldBeEmpty();
+    }
 }

--- a/tests/CommandContextTests/DocumentPaths.cs
+++ b/tests/CommandContextTests/DocumentPaths.cs
@@ -1,0 +1,29 @@
+using System.Collections.Frozen;
+
+using Microsoft.CodeAnalysis;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.CommandContextTests;
+
+public sealed class DocumentPaths
+{
+    [Fact]
+    public void WhenCreatedWithDocumentPaths_ExposesProvidedSet()
+    {
+        // Arrange
+        StringWriter stdout = new();
+        StringWriter stderr = new();
+        Solution solution = null!;
+        List<string> pathList = [@"C:\src\Foo.cs", @"C:\src\Bar.cs"];
+        FrozenSet<string> paths = pathList.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+        // Act
+        CommandContext context = new(stdout, stderr, solution, documentPaths: paths);
+
+        // Assert
+        context.DocumentPaths.ShouldBeSameAs(paths);
+    }
+}

--- a/tests/CommandDispatcherTests/DescribeCommand.cs
+++ b/tests/CommandDispatcherTests/DescribeCommand.cs
@@ -18,10 +18,10 @@ public sealed class DescribeCommand
         string source = @"
 namespace TestApp;
 class Foo { }";
-        Solution solution = CreateSolution(source);
+        (Solution solution, FrozenSet<string> documentPaths) = CreateSolution(source);
         StringWriter stdout = new();
         StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution);
+        CommandContext context = new(stdout, stderr, solution, documentPaths: documentPaths);
 
         // Act
         int exitCode = await CommandDispatcher.ExecuteAsync(
@@ -46,10 +46,10 @@ namespace Beta
 {
     class Widget { }
 }";
-        Solution solution = CreateSolution(source);
+        (Solution solution, FrozenSet<string> documentPaths) = CreateSolution(source);
         StringWriter stdout = new();
         StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution);
+        CommandContext context = new(stdout, stderr, solution, documentPaths: documentPaths);
 
         // Act
         int exitCode = await CommandDispatcher.ExecuteAsync(
@@ -70,10 +70,10 @@ namespace Beta
         string source = @"
 namespace App;
 class MyService { }";
-        Solution solution = CreateSolution(source);
+        (Solution solution, FrozenSet<string> documentPaths) = CreateSolution(source);
         StringWriter stdout = new();
         StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution);
+        CommandContext context = new(stdout, stderr, solution, documentPaths: documentPaths);
 
         // Act
         int exitCode = await CommandDispatcher.ExecuteAsync(
@@ -94,10 +94,10 @@ class MyService { }";
 namespace App;
 class Animal { }
 class Dog : Animal { }";
-        Solution solution = CreateSolution(source);
+        (Solution solution, FrozenSet<string> documentPaths) = CreateSolution(source);
         StringWriter stdout = new();
         StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution);
+        CommandContext context = new(stdout, stderr, solution, documentPaths: documentPaths);
 
         // Act
         int exitCode = await CommandDispatcher.ExecuteAsync(
@@ -117,10 +117,10 @@ class Dog : Animal { }";
         string source = @"
 namespace App;
 class Standalone { }";
-        Solution solution = CreateSolution(source);
+        (Solution solution, FrozenSet<string> documentPaths) = CreateSolution(source);
         StringWriter stdout = new();
         StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution);
+        CommandContext context = new(stdout, stderr, solution, documentPaths: documentPaths);
 
         // Act
         int exitCode = await CommandDispatcher.ExecuteAsync(
@@ -142,10 +142,10 @@ namespace App;
 interface IFoo { }
 interface IBar { }
 class Widget : IFoo, IBar { }";
-        Solution solution = CreateSolution(source);
+        (Solution solution, FrozenSet<string> documentPaths) = CreateSolution(source);
         StringWriter stdout = new();
         StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution);
+        CommandContext context = new(stdout, stderr, solution, documentPaths: documentPaths);
 
         // Act
         int exitCode = await CommandDispatcher.ExecuteAsync(
@@ -165,10 +165,10 @@ class Widget : IFoo, IBar { }";
         string source = @"
 namespace App;
 class Plain { }";
-        Solution solution = CreateSolution(source);
+        (Solution solution, FrozenSet<string> documentPaths) = CreateSolution(source);
         StringWriter stdout = new();
         StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution);
+        CommandContext context = new(stdout, stderr, solution, documentPaths: documentPaths);
 
         // Act
         int exitCode = await CommandDispatcher.ExecuteAsync(
@@ -189,10 +189,10 @@ class Plain { }";
 namespace App;
 interface IBase { }
 interface IChild : IBase { }";
-        Solution solution = CreateSolution(source);
+        (Solution solution, FrozenSet<string> documentPaths) = CreateSolution(source);
         StringWriter stdout = new();
         StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution);
+        CommandContext context = new(stdout, stderr, solution, documentPaths: documentPaths);
 
         // Act
         int exitCode = await CommandDispatcher.ExecuteAsync(
@@ -221,10 +221,10 @@ class Service
     public int Calculate(int x) { return x; }
     public void Reset() { }
 }";
-        Solution solution = CreateSolution(source);
+        (Solution solution, FrozenSet<string> documentPaths) = CreateSolution(source);
         StringWriter stdout = new();
         StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution);
+        CommandContext context = new(stdout, stderr, solution, documentPaths: documentPaths);
 
         // Act
         int exitCode = await CommandDispatcher.ExecuteAsync(
@@ -244,10 +244,10 @@ class Service
         string source = @"
 namespace App;
 interface IEmpty { }";
-        Solution solution = CreateSolution(source);
+        (Solution solution, FrozenSet<string> documentPaths) = CreateSolution(source);
         StringWriter stdout = new();
         StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution);
+        CommandContext context = new(stdout, stderr, solution, documentPaths: documentPaths);
 
         // Act
         int exitCode = await CommandDispatcher.ExecuteAsync(
@@ -267,10 +267,10 @@ interface IEmpty { }";
         string source = @"
 namespace App;
 enum Color { Red, Green, Blue }";
-        Solution solution = CreateSolution(source);
+        (Solution solution, FrozenSet<string> documentPaths) = CreateSolution(source);
         StringWriter stdout = new();
         StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution);
+        CommandContext context = new(stdout, stderr, solution, documentPaths: documentPaths);
 
         // Act
         int exitCode = await CommandDispatcher.ExecuteAsync(
@@ -295,7 +295,7 @@ namespace App;
 class MyService { }";
         Directory.CreateDirectory(srcDir);
         await File.WriteAllTextAsync(absolutePath, source);
-        Solution solution = CreateSolution(source, absolutePath);
+        (Solution solution, _) = CreateSolution(source, absolutePath);
         StringWriter stdout = new();
         StringWriter stderr = new();
         FrozenSet<string> documentPaths = FrozenSet.Create(absolutePath);
@@ -327,10 +327,10 @@ class MyService { }";
     {
         // Arrange
         string source = "class C { }";
-        Solution solution = CreateSolution(source);
+        (Solution solution, FrozenSet<string> documentPaths) = CreateSolution(source);
         StringWriter stdout = new();
         StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution);
+        CommandContext context = new(stdout, stderr, solution, documentPaths: documentPaths);
         using CancellationTokenSource cts = new();
         await cts.CancelAsync();
 
@@ -342,7 +342,7 @@ class MyService { }";
                 cts.Token));
     }
 
-    private static Solution CreateSolution(
+    private static (Solution Solution, FrozenSet<string> DocumentPaths) CreateSolution(
         string source,
         string? documentPath = null)
     {
@@ -366,6 +366,7 @@ class MyService { }";
             filePath: documentPath);
         workspace.AddDocument(docInfo);
         Solution solution = workspace.CurrentSolution;
-        return solution;
+        FrozenSet<string> documentPaths = TrackedFiles.CollectDocumentPaths(solution);
+        return (solution, documentPaths);
     }
 }

--- a/tests/CommandDispatcherTests/DescribeCommand.cs
+++ b/tests/CommandDispatcherTests/DescribeCommand.cs
@@ -355,10 +355,14 @@ class MyService { }";
                 MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
             ]);
         Project project = workspace.AddProject(projectInfo);
-        Document document = workspace.AddDocument(
-            project.Id,
-            documentPath ?? "Test.cs",
-            SourceText.From(source));
-        return document.Project.Solution;
+        string resolvedPath = documentPath ?? "Test.cs";
+        DocumentInfo docInfo = DocumentInfo.Create(
+            DocumentId.CreateNewId(project.Id),
+            name: resolvedPath,
+            loader: TextLoader.From(TextAndVersion.Create(SourceText.From(source), VersionStamp.Default)),
+            filePath: documentPath);
+        workspace.AddDocument(docInfo);
+        Solution solution = workspace.CurrentSolution;
+        return solution;
     }
 }

--- a/tests/CommandDispatcherTests/DescribeCommand.cs
+++ b/tests/CommandDispatcherTests/DescribeCommand.cs
@@ -295,10 +295,9 @@ namespace App;
 class MyService { }";
         Directory.CreateDirectory(srcDir);
         await File.WriteAllTextAsync(absolutePath, source);
-        (Solution solution, _) = CreateSolution(source, absolutePath);
+        (Solution solution, FrozenSet<string> documentPaths) = CreateSolution(source, absolutePath);
         StringWriter stdout = new();
         StringWriter stderr = new();
-        FrozenSet<string> documentPaths = FrozenSet.Create(absolutePath);
         CommandContext context = new(stdout, stderr, solution, tempDir, documentPaths);
 
         // Act & Assert

--- a/tests/CommandDispatcherTests/DescribeCommand.cs
+++ b/tests/CommandDispatcherTests/DescribeCommand.cs
@@ -1,3 +1,5 @@
+using System.Collections.Frozen;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
 
@@ -296,7 +298,8 @@ class MyService { }";
         Solution solution = CreateSolution(source, absolutePath);
         StringWriter stdout = new();
         StringWriter stderr = new();
-        CommandContext context = new(stdout, stderr, solution, tempDir);
+        FrozenSet<string> documentPaths = FrozenSet.Create(absolutePath);
+        CommandContext context = new(stdout, stderr, solution, tempDir, documentPaths);
 
         // Act & Assert
         try

--- a/tests/DaemonIntegrationTests/ReloadDuringCommand.cs
+++ b/tests/DaemonIntegrationTests/ReloadDuringCommand.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.IO.Pipes;
 
 using Microsoft.CodeAnalysis;
@@ -65,7 +66,7 @@ public sealed class ReloadDuringCommand
         wasReloading.ShouldBeTrue();
         stderr.ToString().ShouldBe("daemon: workspace reloading");
 
-        reloadState.CompleteReload(solution, []);
+        reloadState.CompleteReload(solution, [], FrozenSet<string>.Empty);
 
         reloadState.Solution.ShouldNotBeNull();
     }

--- a/tests/LocationFormatterTests/Format.cs
+++ b/tests/LocationFormatterTests/Format.cs
@@ -1,3 +1,5 @@
+using System.Collections.Frozen;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
@@ -24,7 +26,7 @@ public sealed class Format
             .GetLineSpan();
 
         // Act
-        string? result = LocationFormatter.Format(span, context: false, tree);
+        string? result = LocationFormatter.Format(span, context: false, tree, FrozenSet<string>.Empty);
 
         // Assert
         result.ShouldBe($"{TestFilePath}:1");
@@ -40,7 +42,7 @@ public sealed class Format
             new LinePosition(0, 5));
 
         // Act
-        string? result = LocationFormatter.Format(span, context: true, tree: null);
+        string? result = LocationFormatter.Format(span, context: true, tree: null, FrozenSet<string>.Empty);
 
         // Assert
         result.ShouldBe($"{TestFilePath}:1");
@@ -57,7 +59,7 @@ public sealed class Format
             .GetLineSpan();
 
         // Act
-        string? result = LocationFormatter.Format(span, context: true, tree);
+        string? result = LocationFormatter.Format(span, context: true, tree, FrozenSet<string>.Empty);
 
         // Assert
         result.ShouldBe($"{TestFilePath}:1\tclass Foo {{ }}");
@@ -75,7 +77,7 @@ public sealed class Format
             new LinePosition(3, 18));
 
         // Act
-        string? result = LocationFormatter.Format(span, context: true, tree);
+        string? result = LocationFormatter.Format(span, context: true, tree, FrozenSet<string>.Empty);
 
         // Assert
         result.ShouldBe($"{TestFilePath}:4\tclass Bar {{ }}");
@@ -94,7 +96,7 @@ public sealed class Format
             new LinePosition(99, 5));
 
         // Act
-        string? result = LocationFormatter.Format(span, context: true, tree);
+        string? result = LocationFormatter.Format(span, context: true, tree, FrozenSet<string>.Empty);
 
         // Assert
         result.ShouldBe($"{TestFilePath}:100");
@@ -104,19 +106,39 @@ public sealed class Format
     public void WhenPathIsNonEmptyAndFileDoesNotExist_ReturnsNull()
     {
         // Arrange
-        string nonExistentPath = Path.Combine(
+        string absolutePath = Path.Combine(
             Path.GetTempPath(),
             $"{Guid.NewGuid()}.cs");
         FileLinePositionSpan span = new(
-            nonExistentPath,
+            absolutePath,
             new LinePosition(0, 0),
             new LinePosition(0, 5));
 
         // Act
-        string? result = LocationFormatter.Format(span, context: false, tree: null);
+        string? result = LocationFormatter.Format(span, context: false, tree: null, FrozenSet<string>.Empty);
 
         // Assert
         result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void WhenPathIsInDocumentSet_FormatsNormally()
+    {
+        // Arrange
+        string absolutePath = Path.Combine(
+            Path.GetTempPath(),
+            $"{Guid.NewGuid()}.cs");
+        FrozenSet<string> documentPaths = new[] { absolutePath }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+        FileLinePositionSpan span = new(
+            absolutePath,
+            new LinePosition(0, 0),
+            new LinePosition(0, 5));
+
+        // Act
+        string? result = LocationFormatter.Format(span, context: false, tree: null, documentPaths);
+
+        // Assert
+        result.ShouldBe($"{absolutePath}:1");
     }
 
     [Fact]
@@ -129,7 +151,7 @@ public sealed class Format
             new LinePosition(0, 5));
 
         // Act
-        string? result = LocationFormatter.Format(span, context: false, tree: null);
+        string? result = LocationFormatter.Format(span, context: false, tree: null, FrozenSet<string>.Empty);
 
         // Assert
         result.ShouldBe(":1");
@@ -147,7 +169,7 @@ public sealed class Format
             new LinePosition(0, 5));
 
         // Act
-        string? result = LocationFormatter.Format(span, context: false, tree: null);
+        string? result = LocationFormatter.Format(span, context: false, tree: null, FrozenSet<string>.Empty);
 
         // Assert
         result.ShouldBe(@"src/Missing.cs:1");

--- a/tests/LocationFormatterTests/FormatWithBasePath.cs
+++ b/tests/LocationFormatterTests/FormatWithBasePath.cs
@@ -1,3 +1,5 @@
+using System.Collections.Frozen;
+
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
@@ -8,40 +10,28 @@ using Shouldly;
 
 namespace roslyn_query.Tests.LocationFormatterTests;
 
-public sealed class FormatWithBasePath : IDisposable
+public sealed class FormatWithBasePath
 {
-    private readonly string _tempDir;
-    private readonly string _absolutePath;
-
-    public FormatWithBasePath()
-    {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"rq-tests-{Guid.NewGuid()}");
-        string srcDir = Path.Combine(_tempDir, "src");
-        Directory.CreateDirectory(srcDir);
-        _absolutePath = Path.Combine(srcDir, "Foo.cs");
-        File.WriteAllText(_absolutePath, "class Foo { }");
-    }
-
-    public void Dispose()
-    {
-        Directory.Delete(_tempDir, recursive: true);
-    }
+    private static readonly string AbsolutePath = Path.Combine(@"C:\projects\my-solution", "src", "Foo.cs");
+    private static readonly string TempDir = Path.Combine(@"C:\projects\my-solution");
+    private static readonly FrozenSet<string> DocumentPaths =
+        new[] { AbsolutePath }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 
     [Fact]
-    public void WhenPathExistsOnDisk_FormatsNormally()
+    public void WhenPathIsInDocumentSet_FormatsNormally()
     {
         // Arrange
         FileLinePositionSpan span = new(
-            _absolutePath,
+            AbsolutePath,
             new LinePosition(0, 0),
             new LinePosition(0, 5));
 
         // Act
-        string? result = LocationFormatter.Format(span, context: false, tree: null);
+        string? result = LocationFormatter.Format(span, context: false, tree: null, DocumentPaths);
 
         // Assert
         result.ShouldNotBeNull();
-        result.ShouldBe($"{_absolutePath}:1");
+        result.ShouldBe($"{AbsolutePath}:1");
     }
 
     [Fact]
@@ -50,7 +40,7 @@ public sealed class FormatWithBasePath : IDisposable
         // Arrange
         SyntaxTree tree = CSharpSyntaxTree.ParseText(
             "class Foo { }",
-            path: _absolutePath);
+            path: AbsolutePath);
         FileLinePositionSpan span = tree.GetRoot()
             .GetLocation()
             .GetLineSpan();
@@ -60,7 +50,8 @@ public sealed class FormatWithBasePath : IDisposable
             span,
             context: false,
             tree,
-            basePath: _tempDir);
+            DocumentPaths,
+            basePath: TempDir);
 
         // Assert
         string expected = Path.Combine("src", "Foo.cs");
@@ -73,7 +64,7 @@ public sealed class FormatWithBasePath : IDisposable
         // Arrange
         SyntaxTree tree = CSharpSyntaxTree.ParseText(
             "class Foo { }",
-            path: _absolutePath);
+            path: AbsolutePath);
         FileLinePositionSpan span = tree.GetRoot()
             .GetLocation()
             .GetLineSpan();
@@ -83,10 +74,11 @@ public sealed class FormatWithBasePath : IDisposable
             span,
             context: false,
             tree,
+            DocumentPaths,
             basePath: null);
 
         // Assert
-        result.ShouldBe($"{_absolutePath}:1");
+        result.ShouldBe($"{AbsolutePath}:1");
     }
 
     [Fact]
@@ -94,8 +86,7 @@ public sealed class FormatWithBasePath : IDisposable
     {
         // Arrange
         string source = "    class Foo { }";
-        File.WriteAllText(_absolutePath, source);
-        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, path: _absolutePath);
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source, path: AbsolutePath);
         FileLinePositionSpan span = tree.GetRoot()
             .GetLocation()
             .GetLineSpan();
@@ -105,7 +96,8 @@ public sealed class FormatWithBasePath : IDisposable
             span,
             context: true,
             tree,
-            basePath: _tempDir);
+            DocumentPaths,
+            basePath: TempDir);
 
         // Assert
         string expected = Path.Combine("src", "Foo.cs");

--- a/tests/LocationFormatterTests/FormatWithBasePath.cs
+++ b/tests/LocationFormatterTests/FormatWithBasePath.cs
@@ -12,8 +12,8 @@ namespace roslyn_query.Tests.LocationFormatterTests;
 
 public sealed class FormatWithBasePath
 {
-    private static readonly string AbsolutePath = Path.Combine(@"C:\projects\my-solution", "src", "Foo.cs");
-    private static readonly string TempDir = Path.Combine(@"C:\projects\my-solution");
+    private static readonly string AbsolutePath = Path.Combine(Path.GetTempPath(), "my-solution", "src", "Foo.cs");
+    private static readonly string TempDir = Path.Combine(Path.GetTempPath(), "my-solution");
     private static readonly FrozenSet<string> DocumentPaths =
         new[] { AbsolutePath }.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
 

--- a/tests/ReloadStateTests/CompleteReload.cs
+++ b/tests/ReloadStateTests/CompleteReload.cs
@@ -26,7 +26,7 @@ public sealed class CompleteReload
         {
             for (int i = 0; i < iterations; i++)
             {
-                sut.CompleteReload(initialSolution, []);
+                sut.CompleteReload(initialSolution, [], FrozenSet<string>.Empty);
             }
         });
 

--- a/tests/ReloadStateTests/CompleteReload.cs
+++ b/tests/ReloadStateTests/CompleteReload.cs
@@ -1,3 +1,5 @@
+using System.Collections.Frozen;
+
 using Microsoft.CodeAnalysis;
 
 using RoslynQuery;
@@ -52,5 +54,23 @@ public sealed class CompleteReload
 
         // Assert
         readerException.ShouldBeNull();
+    }
+
+    [Fact]
+    public void WhenCompleteReloadCalledWithDocumentPaths_UpdatesDocumentPaths()
+    {
+        // Arrange
+        using AdhocWorkspace workspace = new();
+        Solution solution = workspace.CurrentSolution;
+        ReloadState sut = new(solution, []);
+        List<string> pathList = [@"C:\src\Foo.cs"];
+        FrozenSet<string> updatedPaths = pathList.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+        // Act
+        sut.TryBeginReload().ShouldBeTrue();
+        sut.CompleteReload(solution, [], updatedPaths);
+
+        // Assert
+        sut.DocumentPaths.ShouldBeSameAs(updatedPaths);
     }
 }

--- a/tests/ReloadStateTests/DocumentPaths.cs
+++ b/tests/ReloadStateTests/DocumentPaths.cs
@@ -1,0 +1,42 @@
+using System.Collections.Frozen;
+
+using Microsoft.CodeAnalysis;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.ReloadStateTests;
+
+public sealed class DocumentPaths
+{
+    [Fact]
+    public void WhenConstructedWithoutDocumentPaths_DocumentPathsIsEmpty()
+    {
+        // Arrange
+        using AdhocWorkspace workspace = new();
+        Solution solution = workspace.CurrentSolution;
+
+        // Act
+        ReloadState sut = new(solution, []);
+
+        // Assert
+        sut.DocumentPaths.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void WhenConstructedWithDocumentPaths_ExposesProvidedSet()
+    {
+        // Arrange
+        using AdhocWorkspace workspace = new();
+        Solution solution = workspace.CurrentSolution;
+        List<string> pathList = [@"C:\src\Foo.cs"];
+        FrozenSet<string> documentPaths = pathList.ToFrozenSet(StringComparer.OrdinalIgnoreCase);
+
+        // Act
+        ReloadState sut = new(solution, [], documentPaths);
+
+        // Assert
+        sut.DocumentPaths.ShouldBeSameAs(documentPaths);
+    }
+}

--- a/tests/ReloadStateTests/TrackedPaths.cs
+++ b/tests/ReloadStateTests/TrackedPaths.cs
@@ -1,3 +1,5 @@
+using System.Collections.Frozen;
+
 using Microsoft.CodeAnalysis;
 
 using RoslynQuery;
@@ -46,7 +48,7 @@ public sealed class TrackedPaths
 
             // Act
             sut.TryBeginReload().ShouldBeTrue();
-            sut.CompleteReload(solution, updatedPaths);
+            sut.CompleteReload(solution, updatedPaths, FrozenSet<string>.Empty);
 
             // Assert
             sut.TrackedPaths.ShouldBe(updatedPaths);

--- a/tests/TrackedFilesTests/CollectDocumentPaths.cs
+++ b/tests/TrackedFilesTests/CollectDocumentPaths.cs
@@ -1,0 +1,86 @@
+using System.Collections.Frozen;
+
+using Microsoft.CodeAnalysis;
+
+using RoslynQuery;
+
+using Shouldly;
+
+namespace roslyn_query.Tests.TrackedFilesTests;
+
+public sealed class CollectDocumentPaths
+{
+    [Fact]
+    public void WhenSolutionHasNoDocuments_ReturnsEmptySet()
+    {
+        // Arrange
+        using AdhocWorkspace workspace = new();
+        Solution solution = workspace.CurrentSolution;
+
+        // Act
+        FrozenSet<string> paths = TrackedFiles.CollectDocumentPaths(solution);
+
+        // Assert
+        paths.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void WhenDocumentHasNullFilePath_ExcludesIt()
+    {
+        // Arrange
+        using AdhocWorkspace workspace = new();
+        ProjectId projectId = ProjectId.CreateNewId();
+        DocumentId documentId = DocumentId.CreateNewId(projectId);
+
+        Solution solution = workspace
+            .CurrentSolution
+            .AddProject(projectId, "Alpha", "Alpha", LanguageNames.CSharp)
+            .AddDocument(documentId, "Foo.cs", "class Foo {}", filePath: null);
+
+        // Act
+        FrozenSet<string> paths = TrackedFiles.CollectDocumentPaths(solution);
+
+        // Assert
+        paths.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void ReturnedSet_IsCaseInsensitive()
+    {
+        // Arrange
+        using AdhocWorkspace workspace = new();
+        ProjectId projectId = ProjectId.CreateNewId();
+        DocumentId documentId = DocumentId.CreateNewId(projectId);
+
+        Solution solution = workspace
+            .CurrentSolution
+            .AddProject(projectId, "Alpha", "Alpha", LanguageNames.CSharp)
+            .AddDocument(documentId, "Foo.cs", "class Foo {}", filePath: @"C:\src\Foo.cs");
+
+        // Act
+        FrozenSet<string> paths = TrackedFiles.CollectDocumentPaths(solution);
+
+        // Assert
+        paths.Contains(@"C:\SRC\FOO.CS").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void WhenSolutionHasDocuments_ReturnsAllFilePaths()
+    {
+        // Arrange
+        using AdhocWorkspace workspace = new();
+        ProjectId projectId = ProjectId.CreateNewId();
+        DocumentId documentId = DocumentId.CreateNewId(projectId);
+
+        Solution solution = workspace
+            .CurrentSolution
+            .AddProject(projectId, "Alpha", "Alpha", LanguageNames.CSharp)
+            .AddDocument(documentId, "Foo.cs", "class Foo {}", filePath: @"C:\src\Foo.cs");
+
+        // Act
+        FrozenSet<string> paths = TrackedFiles.CollectDocumentPaths(solution);
+
+        // Assert
+        paths.ShouldContain(@"C:\src\Foo.cs");
+    }
+}


### PR DESCRIPTION
## Summary

- Replace per-location `File.Exists` call in `LocationFormatter.Format()` with a `FrozenSet<string>` membership check against document paths captured from the Roslyn workspace at load time
- Add `TrackedFiles.CollectDocumentPaths(Solution)` returning `FrozenSet<string>` with `StringComparer.OrdinalIgnoreCase`
- Thread document paths through `CommandContext`, `ReloadState`, and `CommandDispatcher.FormatLocation`
- Rename `"(deleted)"` fallback to `"(external)"` in `find-base` and `describe` commands

Closes #61

## Test plan

- [x] Existing tests updated to use `FrozenSet<string>` instead of temp files
- [x] New tests for `CollectDocumentPaths` (empty solution, null file paths, case-insensitive membership)
- [x] New tests for `DocumentPaths` on `CommandContext` and `ReloadState`
- [x] Verified `--count`, `--limit`, `--in-project` flags forward `DocumentPaths` correctly
- [x] All 254 tests pass