### PR TITLE
fix(list-members): handle interface inheritance, explicit implementations, and error-type diagnostics

### DIFF
--- a/src/CommandDispatcher.cs
+++ b/src/CommandDispatcher.cs
@@ -1077,7 +1077,7 @@ public static class CommandDispatcher
                 await ctx.Stdout.WriteLineAsync($"# {t.ToDisplayString()}");
             }
 
-            IReadOnlyList<string> lines = MemberFormatter.FormatMembers(t, inherited);
+            IReadOnlyList<string> lines = MemberFormatter.FormatMembers(t, inherited, ctx.Stderr);
             foreach (string line in lines)
             {
                 await ctx.Stdout.WriteLineAsync(line);

--- a/src/MemberFormatter.cs
+++ b/src/MemberFormatter.cs
@@ -32,7 +32,7 @@ public static class MemberFormatter
         {
             if (type.TypeKind == TypeKind.Interface)
             {
-                HashSet<string> seen = new(results.Select(r => r.Split('\t')[1]));
+                HashSet<string> seen = new(results, StringComparer.Ordinal);
                 foreach (INamedTypeSymbol parentInterface in type.AllInterfaces)
                 {
                     string declaringType = parentInterface.ToDisplayString(DeclaringTypeFormat);
@@ -112,7 +112,7 @@ public static class MemberFormatter
             IMethodSymbol m when m.MethodKind == MethodKind.Ordinary =>
                 $"method\t{m.ReturnType.ToDisplayString()} {m.Name}({string.Join(", ", m.Parameters.Select(p => $"{p.Type.ToDisplayString()} {p.Name}"))})",
             IMethodSymbol m when m.MethodKind == MethodKind.ExplicitInterfaceImplementation =>
-                $"method\t{m.ReturnType.ToDisplayString()} {m.ExplicitInterfaceImplementations[0].ContainingType.Name}.{m.ExplicitInterfaceImplementations[0].Name}({string.Join(", ", m.Parameters.Select(p => $"{p.Type.ToDisplayString()} {p.Name}"))})",
+                FormatExplicitInterfaceImplementation(m),
             IMethodSymbol m when m.MethodKind == MethodKind.Constructor =>
                 $"constructor\t{m.ContainingType.Name}({string.Join(", ", m.Parameters.Select(p => $"{p.Type.ToDisplayString()} {p.Name}"))})",
             IFieldSymbol f =>
@@ -121,5 +121,19 @@ public static class MemberFormatter
                 $"event\t{e.Type.ToDisplayString()} {e.Name}",
             _ => null
         };
+    }
+
+    private static string? FormatExplicitInterfaceImplementation(IMethodSymbol method)
+    {
+        if (method.ExplicitInterfaceImplementations.IsEmpty)
+        {
+            return null;
+        }
+
+        IMethodSymbol interfaceMethod = method.ExplicitInterfaceImplementations[0];
+        string parameters = string.Join(
+            ", ",
+            method.Parameters.Select(p => $"{p.Type.ToDisplayString()} {p.Name}"));
+        return $"method\t{method.ReturnType.ToDisplayString()} {interfaceMethod.ContainingType.Name}.{interfaceMethod.Name}({parameters})";
     }
 }

--- a/src/MemberFormatter.cs
+++ b/src/MemberFormatter.cs
@@ -7,7 +7,10 @@ public static class MemberFormatter
     private static readonly SymbolDisplayFormat DeclaringTypeFormat = new(
         typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
 
-    public static IReadOnlyList<string> FormatMembers(INamedTypeSymbol type, bool inherited)
+    public static IReadOnlyList<string> FormatMembers(
+        INamedTypeSymbol type,
+        bool inherited,
+        TextWriter? stderr = null)
     {
         ArgumentNullException.ThrowIfNull(type);
 
@@ -20,31 +23,79 @@ public static class MemberFormatter
             string? formatted = FormatMember(member);
             if (formatted is not null)
             {
+                EmitUnresolvedTypeWarnings(member, stderr);
                 results.Add(formatted);
             }
         }
 
         if (inherited)
         {
-            INamedTypeSymbol? baseType = type.BaseType;
-            while (baseType is not null)
+            if (type.TypeKind == TypeKind.Interface)
             {
-                string declaringType = baseType.ToDisplayString(DeclaringTypeFormat);
-                foreach (ISymbol member in baseType.GetMembers()
-                    .OrderBy(m => m.Kind)
-                    .ThenBy(m => m.Name))
+                HashSet<string> seen = new(results.Select(r => r.Split('\t')[1]));
+                foreach (INamedTypeSymbol parentInterface in type.AllInterfaces)
                 {
-                    string? formatted = FormatMember(member);
-                    if (formatted is not null)
+                    string declaringType = parentInterface.ToDisplayString(DeclaringTypeFormat);
+                    foreach (ISymbol member in parentInterface.GetMembers()
+                        .OrderBy(m => m.Kind)
+                        .ThenBy(m => m.Name))
                     {
-                        results.Add($"{formatted}\t{declaringType}");
+                        string? formatted = FormatMember(member);
+                        if (formatted is not null && seen.Add(formatted))
+                        {
+                            EmitUnresolvedTypeWarnings(member, stderr);
+                            results.Add($"{formatted}\t{declaringType}");
+                        }
                     }
                 }
-                baseType = baseType.BaseType;
+            }
+            else
+            {
+                INamedTypeSymbol? baseType = type.BaseType;
+                while (baseType is not null)
+                {
+                    string declaringType = baseType.ToDisplayString(DeclaringTypeFormat);
+                    foreach (ISymbol member in baseType.GetMembers()
+                        .OrderBy(m => m.Kind)
+                        .ThenBy(m => m.Name))
+                    {
+                        string? formatted = FormatMember(member);
+                        if (formatted is not null)
+                        {
+                            EmitUnresolvedTypeWarnings(member, stderr);
+                            results.Add($"{formatted}\t{declaringType}");
+                        }
+                    }
+                    baseType = baseType.BaseType;
+                }
             }
         }
 
         return results;
+    }
+
+    private static void EmitUnresolvedTypeWarnings(ISymbol member, TextWriter? stderr)
+    {
+        if (stderr is null)
+        {
+            return;
+        }
+
+        bool hasErrorType = member switch
+        {
+            IMethodSymbol m => m.ReturnType.TypeKind == TypeKind.Error
+                || m.Parameters.Any(p => p.Type.TypeKind == TypeKind.Error),
+            IPropertySymbol p => p.Type.TypeKind == TypeKind.Error,
+            IFieldSymbol f => f.Type.TypeKind == TypeKind.Error,
+            IEventSymbol e => e.Type.TypeKind == TypeKind.Error,
+            _ => false,
+        };
+
+        if (hasErrorType)
+        {
+            stderr.WriteLine(
+                $"warning: unresolved types in {member.ContainingType.Name}.{member.Name}");
+        }
     }
 
     private static string? FormatMember(ISymbol member)
@@ -60,6 +111,8 @@ public static class MemberFormatter
                 $"property\t{p.Type.ToDisplayString()} {p.Name}",
             IMethodSymbol m when m.MethodKind == MethodKind.Ordinary =>
                 $"method\t{m.ReturnType.ToDisplayString()} {m.Name}({string.Join(", ", m.Parameters.Select(p => $"{p.Type.ToDisplayString()} {p.Name}"))})",
+            IMethodSymbol m when m.MethodKind == MethodKind.ExplicitInterfaceImplementation =>
+                $"method\t{m.ReturnType.ToDisplayString()} {m.ExplicitInterfaceImplementations[0].ContainingType.Name}.{m.ExplicitInterfaceImplementations[0].Name}({string.Join(", ", m.Parameters.Select(p => $"{p.Type.ToDisplayString()} {p.Name}"))})",
             IMethodSymbol m when m.MethodKind == MethodKind.Constructor =>
                 $"constructor\t{m.ContainingType.Name}({string.Join(", ", m.Parameters.Select(p => $"{p.Type.ToDisplayString()} {p.Name}"))})",
             IFieldSymbol f =>

--- a/tests/MemberFormatterTests/FormatMembers.cs
+++ b/tests/MemberFormatterTests/FormatMembers.cs
@@ -184,7 +184,35 @@ class MyClass : IFoo
     }
 
     [Fact]
-    public void WhenMemberHasUnresolvedType_EmitsWarningToStderr_AndStillAppearsInResult()
+    public void WhenClassExplicitlyImplementsTwoInterfacesWithSameMethodName_BothAppearWithQualifiedNames()
+    {
+        // Arrange
+        string source = @"
+interface IFoo
+{
+    void Execute();
+}
+interface IBar
+{
+    void Execute();
+}
+class MyClass : IFoo, IBar
+{
+    void IFoo.Execute() { }
+    void IBar.Execute() { }
+}";
+        INamedTypeSymbol type = GetType(source, "MyClass");
+
+        // Act
+        IReadOnlyList<string> result = MemberFormatter.FormatMembers(type, inherited: false);
+
+        // Assert
+        result.ShouldContain("method\tvoid IFoo.Execute()");
+        result.ShouldContain("method\tvoid IBar.Execute()");
+    }
+
+    [Fact]
+    public void WhenMemberHasUnresolvedType_EmitsWarningToStderr()
     {
         // Arrange
         string source = @"
@@ -202,11 +230,34 @@ class MyClass
         StringWriter stderr = new();
 
         // Act
-        IReadOnlyList<string> result = MemberFormatter.FormatMembers(type, inherited: false, stderr);
+        MemberFormatter.FormatMembers(type, inherited: false, stderr);
+
+        // Assert
+        stderr.ToString().ShouldContain("warning: unresolved types in MyClass.MyMethod");
+    }
+
+    [Fact]
+    public void WhenMemberHasUnresolvedType_StillAppearsInResult()
+    {
+        // Arrange
+        string source = @"
+class MyClass
+{
+    public UnknownType MyMethod(string name) { return null; }
+}";
+        // Compile without any metadata references so UnknownType is an error type
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [tree],
+            []);
+        INamedTypeSymbol type = compilation.GetTypeByMetadataName("MyClass")!;
+
+        // Act
+        IReadOnlyList<string> result = MemberFormatter.FormatMembers(type, inherited: false);
 
         // Assert
         result.ShouldContain(line => line.Contains("MyMethod"));
-        stderr.ToString().ShouldContain("warning: unresolved types in MyClass.MyMethod");
     }
 
     [Fact]
@@ -220,7 +271,10 @@ interface ICommon
 }
 interface IA : ICommon { }
 interface IB : ICommon { }
-interface IChild : IA, IB { }";
+interface IChild : IA, IB
+{
+    void CommonMethod();
+}";
         INamedTypeSymbol type = GetType(source, "IChild");
 
         // Act
@@ -251,6 +305,32 @@ interface IChild : IParent
         // Assert
         result.ShouldContain("method\tvoid ChildMethod()");
         result.ShouldContain("method\tvoid ParentMethod()\tIParent");
+    }
+
+    [Fact]
+    public void WhenInheritedIsTrue_AndInheritedMemberHasUnresolvedType_EmitsWarningToStderr()
+    {
+        // Arrange
+        string source = @"
+class Base
+{
+    public UnknownType InheritedMethod() { return null; }
+}
+class Derived : Base { }";
+        // Compile without any metadata references so UnknownType is an error type
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [tree],
+            []);
+        INamedTypeSymbol type = compilation.GetTypeByMetadataName("Derived")!;
+        StringWriter stderr = new();
+
+        // Act
+        MemberFormatter.FormatMembers(type, inherited: true, stderr);
+
+        // Assert
+        stderr.ToString().ShouldContain("warning: unresolved types in Base.InheritedMethod");
     }
 
     private static INamedTypeSymbol GetType(string source, string typeName)

--- a/tests/MemberFormatterTests/FormatMembers.cs
+++ b/tests/MemberFormatterTests/FormatMembers.cs
@@ -161,6 +161,98 @@ class MyClass { }";
         result.ShouldContain(line => line.Contains("ToString()") && line.EndsWith("\tSystem.Object"));
     }
 
+    [Fact]
+    public void WhenMemberIsExplicitInterfaceImplementation_FormatsWithQualifiedName()
+    {
+        // Arrange
+        string source = @"
+interface IFoo
+{
+    void Bar();
+}
+class MyClass : IFoo
+{
+    void IFoo.Bar() { }
+}";
+        INamedTypeSymbol type = GetType(source, "MyClass");
+
+        // Act
+        IReadOnlyList<string> result = MemberFormatter.FormatMembers(type, inherited: false);
+
+        // Assert
+        result.ShouldContain("method\tvoid IFoo.Bar()");
+    }
+
+    [Fact]
+    public void WhenMemberHasUnresolvedType_EmitsWarningToStderr_AndStillAppearsInResult()
+    {
+        // Arrange
+        string source = @"
+class MyClass
+{
+    public UnknownType MyMethod(string name) { return null; }
+}";
+        // Compile without any metadata references so UnknownType is an error type
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(source);
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            [tree],
+            []);
+        INamedTypeSymbol type = compilation.GetTypeByMetadataName("MyClass")!;
+        StringWriter stderr = new();
+
+        // Act
+        IReadOnlyList<string> result = MemberFormatter.FormatMembers(type, inherited: false, stderr);
+
+        // Assert
+        result.ShouldContain(line => line.Contains("MyMethod"));
+        stderr.ToString().ShouldContain("warning: unresolved types in MyClass.MyMethod");
+    }
+
+    [Fact]
+    public void WhenInheritedIsTrue_AndTypeIsInterface_DiamondInheritanceDeduplicatesMembers()
+    {
+        // Arrange
+        string source = @"
+interface ICommon
+{
+    void CommonMethod();
+}
+interface IA : ICommon { }
+interface IB : ICommon { }
+interface IChild : IA, IB { }";
+        INamedTypeSymbol type = GetType(source, "IChild");
+
+        // Act
+        IReadOnlyList<string> result = MemberFormatter.FormatMembers(type, inherited: true);
+
+        // Assert
+        result.Count(line => line.Contains("CommonMethod", StringComparison.Ordinal)).ShouldBe(1);
+    }
+
+    [Fact]
+    public void WhenInheritedIsTrue_AndTypeIsInterface_IncludesParentInterfaceMembers()
+    {
+        // Arrange
+        string source = @"
+interface IParent
+{
+    void ParentMethod();
+}
+interface IChild : IParent
+{
+    void ChildMethod();
+}";
+        INamedTypeSymbol type = GetType(source, "IChild");
+
+        // Act
+        IReadOnlyList<string> result = MemberFormatter.FormatMembers(type, inherited: true);
+
+        // Assert
+        result.ShouldContain("method\tvoid ChildMethod()");
+        result.ShouldContain("method\tvoid ParentMethod()\tIParent");
+    }
+
     private static INamedTypeSymbol GetType(string source, string typeName)
     {
         SyntaxTree tree = CSharpSyntaxTree.ParseText(source);


### PR DESCRIPTION
## Summary

- Walk `AllInterfaces` when `--inherited` is used on an interface type (previously only walked `BaseType`, which is always `null` for interfaces)
- Format `MethodKind.ExplicitInterfaceImplementation` with interface-qualified names (e.g. `IFoo.Bar`) instead of silently dropping them
- Emit stderr warnings when member signatures contain unresolvable error types, while still including the member in stdout

Closes #65

## Test plan

- [x] Interface inheritance: `IChild : IParent` lists parent members with `--inherited`
- [x] Diamond inheritance: `IChild : IA, IB` where both extend `ICommon` — `ICommon` members appear exactly once
- [x] Explicit interface implementation: class with `void IFoo.Bar()` shows `IFoo.Bar` in output
- [x] Two-interface explicit impl: `IFoo.Execute` and `IBar.Execute` both appear with qualified names
- [x] Unresolved types: member appears in stdout, warning emitted to stderr
- [x] Inherited member with unresolved types: warning emitted for base-class members too
- [x] `FormatExplicitInterfaceImplementation` guards empty `ExplicitInterfaceImplementations` list
- [x] All 261 tests pass