### PR TITLE
fix: rename NuGet package ID to rq-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ A global dotnet CLI tool for semantic C# codebase queries via the Roslyn API. Bu
 Requires .NET 10 SDK.
 
 ```bash
-dotnet tool install --global roslyn-query
+dotnet tool install --global rq-cli
 ```
 
 To update to the latest version:
 
 ```bash
-dotnet tool update --global roslyn-query
+dotnet tool update --global rq-cli
 ```
 
 ## Usage

--- a/src/roslyn-query.csproj
+++ b/src/roslyn-query.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>roslyn-query</AssemblyName>
-    <PackageId>roslyn-query</PackageId>
+    <PackageId>rq-cli</PackageId>
     <ToolCommandName>roslyn-query</ToolCommandName>
     <PackAsTool>true</PackAsTool>
     <Description>A global dotnet CLI tool for semantic C# codebase queries via the Roslyn API. Designed for LLM coding agents — structured tab-delimited output minimizes token usage and enables faster codebase exploration.</Description>


### PR DESCRIPTION
## Summary

- Rename PackageId from `roslyn-query` to `rq-cli` to avoid the reserved `roslyn-` prefix on nuget.org
- Update README install/update instructions accordingly
- The CLI command remains `roslyn-query` (ToolCommandName unchanged)

Fixes #71